### PR TITLE
MET-665: handle n+1 problem and optimize query get tx by stake

### DIFF
--- a/src/main/java/org/cardanofoundation/explorer/api/repository/AddressTokenRepository.java
+++ b/src/main/java/org/cardanofoundation/explorer/api/repository/AddressTokenRepository.java
@@ -57,7 +57,7 @@ public interface AddressTokenRepository extends JpaRepository<AddressToken, Long
                                               @Param("address") String address);
 
   @Query("SELECT addrToken FROM AddressToken addrToken"
-      + " WHERE addrToken.tx.id in :ids and addrToken.addressId in :addressIds")
-  List<AddressToken> findByTxIdInAndByAddressIn(@Param("ids") Collection<Long> ids,
-                                                @Param("addressIds") Set<Long> addressIds);
+      + " WHERE addrToken.tx.id in :ids and addrToken.address.stakeAddress.id = :stakeId")
+  List<AddressToken> findByTxIdInAndStakeId(@Param("ids") Collection<Long> ids,
+                                            @Param("stakeId") Long stakeId);
 }

--- a/src/main/java/org/cardanofoundation/explorer/api/repository/AddressTxBalanceRepository.java
+++ b/src/main/java/org/cardanofoundation/explorer/api/repository/AddressTxBalanceRepository.java
@@ -2,7 +2,6 @@ package org.cardanofoundation.explorer.api.repository;
 
 import java.util.Collection;
 import org.cardanofoundation.explorer.api.projection.MinMaxProjection;
-import java.util.Set;
 import org.cardanofoundation.explorer.api.projection.StakeTxProjection;
 import org.cardanofoundation.explorer.consumercommon.entity.Address;
 import org.cardanofoundation.explorer.consumercommon.entity.AddressTxBalance;
@@ -70,10 +69,9 @@ public interface AddressTxBalanceRepository extends JpaRepository<AddressTxBalan
 
   @Query(value = "SELECT DISTINCT tx FROM AddressTxBalance addrTxBalance"
       + " INNER JOIN Tx tx ON addrTxBalance.tx = tx"
-      + " WHERE addrTxBalance.address IN "
-      + " (SELECT addr FROM Address addr WHERE addr.stakeAddress.view = :stakeAddress)"
-      + " ORDER BY tx.blockId DESC, tx.blockIndex DESC")
-  Page<Tx> findAllByStake(@Param("stakeAddress") String stakeAddress, Pageable pageable);
+      + " WHERE addrTxBalance.stakeAddress.id = :stakeAddressId "
+      + " ORDER BY tx.id DESC")
+  Page<Tx> findAllByStake(@Param("stakeAddressId") Long stakeAddressId, Pageable pageable);
 
   @Query(value = "SELECT addrTxBalance.tx.id as txId, sum(addrTxBalance.balance) as amount,"
       + " addrTxBalance.time as time"
@@ -96,9 +94,9 @@ public interface AddressTxBalanceRepository extends JpaRepository<AddressTxBalan
                                                   @Param("address") String address);
 
   @Query("SELECT addressTxBalance FROM AddressTxBalance addressTxBalance"
-      + " WHERE addressTxBalance.tx.id in :ids and addressTxBalance.addressId in :addressIds")
-  List<AddressTxBalance> findByTxIdInAndByAddressIn(@Param("ids") Collection<Long> ids,
-                                                    @Param("addressIds") Set<Long> addressIds);
+      + " WHERE addressTxBalance.tx.id in :ids and addressTxBalance.stakeAddress.id = :stakeId")
+  List<AddressTxBalance> findByTxIdInAndStakeId(@Param("ids") Collection<Long> ids,
+                                                @Param("stakeId") Long stakeId);
 
   @Query(value = "SELECT addrTxBalance.tx.id as txId, sum(addrTxBalance.balance) as amount,"
       + " addrTxBalance.time as time"

--- a/src/main/java/org/cardanofoundation/explorer/api/service/impl/TxServiceImpl.java
+++ b/src/main/java/org/cardanofoundation/explorer/api/service/impl/TxServiceImpl.java
@@ -12,6 +12,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -26,6 +27,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 
 import org.cardanofoundation.explorer.api.model.response.tx.*;
+import org.cardanofoundation.explorer.api.repository.StakeAddressRepository;
+import org.cardanofoundation.explorer.consumercommon.entity.StakeAddress;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -33,6 +36,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.util.Pair;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.CollectionUtils;
@@ -146,6 +150,7 @@ public class TxServiceImpl implements TxService {
   private final ParamProposalRepository paramProposalRepository;
   private final EpochParamRepository epochParamRepository;
   private final TxChartRepository txChartRepository;
+  private final StakeAddressRepository stakeAddressRepository;
   private final ProtocolMapper protocolMapper;
 
   private final RedisTemplate<String, TxGraph> redisTemplate;
@@ -268,7 +273,7 @@ public class TxServiceImpl implements TxService {
     List<Tx> txList = addressTxBalanceRepository.findAllByAddress(addr, pageable);
 
     Page<Tx> txPage = new PageImpl<>(txList, pageable, addr.getTxCount());
-    return new BaseFilterResponse<>(txPage, mapDataFromTxByAddressListToResponses(txPage, address));
+    return new BaseFilterResponse<>(txPage, mapDataFromTxByAddressListToResponses(txPage, addr));
   }
 
   @Override
@@ -291,8 +296,12 @@ public class TxServiceImpl implements TxService {
   @Transactional(readOnly = true)
   public BaseFilterResponse<TxFilterResponse> getTransactionsByStake(String stakeKey,
                                                                      Pageable pageable) {
-    Page<Tx> txPage = addressTxBalanceRepository.findAllByStake(stakeKey, pageable);
-    List<TxFilterResponse> data = mapDataFromTxByStakeListToResponseList(txPage, stakeKey);
+    StakeAddress stakeAddress = stakeAddressRepository.findByView(stakeKey).orElseThrow(
+        () -> new BusinessException(BusinessCode.STAKE_ADDRESS_NOT_FOUND)
+    );
+
+    Page<Tx> txPage = addressTxBalanceRepository.findAllByStake(stakeAddress.getId(), pageable);
+    List<TxFilterResponse> data = mapDataFromTxByStakeListToResponseList(txPage, stakeAddress.getId());
     return new BaseFilterResponse<>(txPage, data);
   }
 
@@ -351,77 +360,110 @@ public class TxServiceImpl implements TxService {
   }
 
   private List<TxFilterResponse> mapDataFromTxByAddressListToResponses(Page<Tx> txPage,
-                                                                       String address) {
+                                                                       Address address) {
     List<TxFilterResponse> txFilterResponses = mapDataFromTxListToResponseList(txPage);
 
     Set<Long> txIdList = txPage.getContent().stream().map(Tx::getId).collect(Collectors.toSet());
 
     // get address tx balance
     List<AddressTxBalance> addressTxBalances =
-        addressTxBalanceRepository.findByTxIdInAndByAddress(txIdList, address);
+        addressTxBalanceRepository.findByTxIdInAndByAddress(txIdList, address.getAddress());
     Map<Long, List<AddressTxBalance>> addressTxBalanceMap =
         addressTxBalances.stream().collect(Collectors.groupingBy(AddressTxBalance::getTxId));
 
     // get address token
     List<AddressToken> addressTokens =
-        addressTokenRepository.findByTxIdInAndByAddress(txIdList, address);
+        addressTokenRepository.findByTxIdInAndByAddress(txIdList, address.getAddress());
     Map<Long, List<AddressToken>> addressTokenMap =
         addressTokens.stream()
             .filter(addressToken -> !BigInteger.ZERO.equals(addressToken.getBalance()))
             .collect(Collectors.groupingBy(addressToken -> addressToken.getTx().getId()));
 
+    // get metadata and multi asset
+    Pair<Map<String, AssetMetadata>, Map<Long, MultiAsset>> getMapMetadataAndMapAsset =
+        getMapMetadataAndMapAsset(addressTokens);
+    Map<Long, Address> addressMap = new HashMap<>() {{
+      put(address.getId(), address);
+    }};
+
     txFilterResponses.forEach(
         tx ->
             setAdditionalData(
-                addressTxBalanceMap, addressTokenMap, getMetadata(addressTokens), tx));
+                addressTxBalanceMap,
+                addressTokenMap,
+                getMapMetadataAndMapAsset.getFirst(),
+                getMapMetadataAndMapAsset.getSecond(),
+                addressMap,
+                tx));
     return txFilterResponses;
   }
 
-  private List<TxFilterResponse> mapDataFromTxByStakeListToResponseList(
-      Page<Tx> txPage, String stake) {
+  private List<TxFilterResponse> mapDataFromTxByStakeListToResponseList(Page<Tx> txPage,
+                                                                        Long stakeId) {
     List<TxFilterResponse> txFilterResponses = mapDataFromTxListToResponseList(txPage);
     Set<Long> txIdList = txPage.getContent().stream().map(Tx::getId).collect(Collectors.toSet());
 
-    Set<Long> addressIds = addressRepository.findByStakeAddress(stake).stream().map(Address::getId)
-        .collect(
-            Collectors.toSet());
-
     // get address tx balance
     List<AddressTxBalance> addressTxBalances =
-        addressTxBalanceRepository.findByTxIdInAndByAddressIn(txIdList, addressIds);
+        addressTxBalanceRepository.findByTxIdInAndStakeId(txIdList, stakeId);
 
     Map<Long, List<AddressTxBalance>> addressTxBalanceMap =
         addressTxBalances.stream().collect(Collectors.groupingBy(AddressTxBalance::getTxId));
 
     List<AddressToken> addressTokens =
-        addressTokenRepository.findByTxIdInAndByAddressIn(txIdList, addressIds);
+        addressTokenRepository.findByTxIdInAndStakeId(txIdList, stakeId);
     Map<Long, List<AddressToken>> addressTokenMap =
         addressTokens.stream()
             .filter(addressToken -> !BigInteger.ZERO.equals(addressToken.getBalance()))
             .collect(Collectors.groupingBy(addressToken -> addressToken.getTx().getId()));
 
+    // get metadata and multi asset
+    Pair<Map<String, AssetMetadata>, Map<Long, MultiAsset>> getMapMetadataAndMapAsset =
+        getMapMetadataAndMapAsset(addressTokens);
+
+    // get address
+    Set<Long> addressIdList = addressTokens.stream().map(AddressToken::getAddressId).collect(
+        Collectors.toSet());
+    List<Address> addresses = addressRepository.findAddressByIdIn(addressIdList);
+    Map<Long, Address> addressMap =
+        addresses.stream().collect(Collectors.toMap(Address::getId, Function.identity()));
+
     txFilterResponses.forEach(
         tx ->
             setAdditionalData(
-                addressTxBalanceMap, addressTokenMap, getMetadata(addressTokens), tx));
+                addressTxBalanceMap,
+                addressTokenMap,
+                getMapMetadataAndMapAsset.getFirst(),
+                getMapMetadataAndMapAsset.getSecond(),
+                addressMap,
+                tx));
     return txFilterResponses;
   }
 
-  private Map<String, AssetMetadata> getMetadata(List<AddressToken> addressTokens) {
+  private Pair<Map<String, AssetMetadata>, Map<Long, MultiAsset>> getMapMetadataAndMapAsset(
+      List<AddressToken> addressTokens) {
     List<Long> multiAssetIdList =
         addressTokens.stream().map(AddressToken::getMultiAssetId).toList();
     List<MultiAsset> multiAssets = multiAssetRepository.findAllByIdIn(multiAssetIdList);
     Set<String> subjects =
         multiAssets.stream().map(ma -> ma.getPolicy() + ma.getName()).collect(Collectors.toSet());
     List<AssetMetadata> assetMetadataList = assetMetadataRepository.findBySubjectIn(subjects);
-    return assetMetadataList.stream()
-        .collect(Collectors.toMap(AssetMetadata::getSubject, Function.identity()));
+    Map<String, AssetMetadata> assetMetadataMap =
+        assetMetadataList.stream()
+            .collect(Collectors.toMap(AssetMetadata::getSubject, Function.identity()));
+
+    Map<Long, MultiAsset> multiAssetMap =
+        multiAssets.stream().collect(Collectors.toMap(MultiAsset::getId, Function.identity()));
+
+    return Pair.of(assetMetadataMap, multiAssetMap);
   }
 
   private void setAdditionalData(
       Map<Long, List<AddressTxBalance>> addressTxBalanceMap,
       Map<Long, List<AddressToken>> addressTokenMap,
       Map<String, AssetMetadata> assetMetadataMap,
+      Map<Long, MultiAsset> multiAssetMap,
+      Map<Long, Address> addressMap,
       TxFilterResponse tx) {
 
     if (addressTxBalanceMap.containsKey(tx.getId())) {
@@ -437,12 +479,21 @@ public class TxServiceImpl implements TxService {
           addressTokenMap.get(tx.getId()).stream()
               .map(
                   addressToken -> {
-                    MultiAsset multiAsset = addressToken.getMultiAsset();
-                    TokenAddressResponse taResponse =
-                        tokenMapper.fromMultiAssetAndAddressToken(multiAsset, addressToken);
-                    String subject = multiAsset.getPolicy() + multiAsset.getName();
-                    taResponse.setMetadata(
-                        assetMetadataMapper.fromAssetMetadata(assetMetadataMap.get(subject)));
+                    MultiAsset multiAsset = multiAssetMap.get(addressToken.getMultiAssetId());
+                    TokenAddressResponse taResponse = new TokenAddressResponse();
+                    if (!Objects.isNull(multiAsset)) {
+                      taResponse =
+                          tokenMapper.fromMultiAssetAndAddressToken(multiAsset, addressToken);
+                      String subject = multiAsset.getPolicy() + multiAsset.getName();
+                      taResponse.setMetadata(
+                          assetMetadataMapper.fromAssetMetadata(assetMetadataMap.get(subject)));
+                    }
+
+                    Address address = addressMap.get(addressToken.getAddressId());
+                    if (!Objects.isNull(address)) {
+                      taResponse.setAddress(address.getAddress());
+                    }
+
                     return taResponse;
                   })
               .toList();


### PR DESCRIPTION
## Subject
- API: /api/v1/stakes/{stakeKey}/txs?page=0&size=20
- Handle n+1 problem.
- Optimize query get transaction by stakeId

## Changes Description

- Adding new column **stake_address_id** to table **address_tx_balance**.
- Create new index for table **address_tx_balance**
 + create index address_tx_balance_stake_address_id_tx_id on address_tx_balance (stake_address_id, tx_id);

## How to test

- Run api **/api/v1/stakes/stake1uy8qghtnjvxce6705degxlzyzjkund3ef6fxq84pfkj06gce3axzp/txs?page=0&size=20**
Try this api with stake with about 400k address. For example: **stake1uy8qghtnjvxce6705degxlzyzjkund3ef6fxq84pfkj06gce3axzp**

## Evident for results
Old query:
    select
        distinct t1_0.id,
        t1_0.block_id,
        t1_0.block_index,
        t1_0.deposit,
        t1_0.fee,
        t1_0.hash,
        t1_0.invalid_before,
        t1_0.invalid_hereafter,
        t1_0.out_sum,
        t1_0.script_size,
        t1_0.size,
        t1_0.valid_contract 
    from
        mainnet.address_tx_balance a1_0 
    join
        mainnet.tx t1_0 
            on a1_0.tx_id=t1_0.id 
    where
        a1_0.address_id in(select
            a3_0.id 
        from
            mainnet.address a3_0 
        join
            mainnet.stake_address s1_0 
                on s1_0.id=a3_0.stake_address_id 
        where
            s1_0.id=2072434) 
    order by
        t1_0.block_id desc,
        t1_0.block_index desc offset 0 rows fetch first 20 rows only;
![image](https://github.com/cardano-foundation/cf-explorer-api/assets/132549582/f1aaae8b-0627-49b5-9cfc-8318fa3cb3c2)

New query:
    select
        distinct t1_0.id,
        t1_0.block_id,
        t1_0.block_index,
        t1_0.deposit,
        t1_0.fee,
        t1_0.hash,
        t1_0.invalid_before,
        t1_0.invalid_hereafter,
        t1_0.out_sum,
        t1_0.script_size,
        t1_0.size,
        t1_0.valid_contract 
    from
        mainnet.address_tx_balance a1_0 
    join
        mainnet.tx t1_0 
            on a1_0.tx_id=t1_0.id 
    where
        a1_0.stake_address_id=? 
    order by
        t1_0.id desc offset ? rows fetch first ? rows only
![image](https://github.com/cardano-foundation/cf-explorer-api/assets/132549582/23681536-73e9-4ff8-bdee-4c6fe9d98c2d)

## Referenced Ticket

- https://cardanofoundation.atlassian.net/browse/MET-665
