### PR TITLE
fix: show total value delegators tab in pool detail

### DIFF
--- a/src/main/java/org/cardanofoundation/explorer/api/repository/EpochStakeCheckpointRepository.java
+++ b/src/main/java/org/cardanofoundation/explorer/api/repository/EpochStakeCheckpointRepository.java
@@ -1,0 +1,17 @@
+package org.cardanofoundation.explorer.api.repository;
+
+import java.util.List;
+import org.cardanofoundation.explorer.consumercommon.entity.EpochStakeCheckpoint;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface EpochStakeCheckpointRepository extends JpaRepository<EpochStakeCheckpoint, Long> {
+
+  @Query("SELECT COUNT(r.id) FROM EpochStakeCheckpoint r "
+      + "WHERE r.stakeAddress IN :rewardAccounts AND r.epochCheckpoint = "
+      + "(SELECT max(e.no) FROM Epoch e)")
+  Integer checkEpochStakeByAccountsAndEpoch(@Param("rewardAccounts") List<String> rewardAccounts);
+}

--- a/src/main/java/org/cardanofoundation/explorer/api/service/FetchRewardDataService.java
+++ b/src/main/java/org/cardanofoundation/explorer/api/service/FetchRewardDataService.java
@@ -21,5 +21,9 @@ public interface FetchRewardDataService {
 
   Boolean fetchRewardForPool(List<String> rewardAccounts);
 
+  Boolean checkEpochStakeForPool(List<String> rewardAccounts);
+
+  Boolean fetchEpochStakeForPool(List<String> rewardAccounts);
+
   Boolean isKoiOs();
 }

--- a/src/main/java/org/cardanofoundation/explorer/api/service/impl/FetchRewardDataFromKoiosServiceImpl.java
+++ b/src/main/java/org/cardanofoundation/explorer/api/service/impl/FetchRewardDataFromKoiosServiceImpl.java
@@ -7,6 +7,7 @@ import java.util.Objects;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
 
+import org.cardanofoundation.explorer.api.repository.EpochStakeCheckpointRepository;
 import org.cardanofoundation.explorer.api.repository.PoolHistoryCheckpointRepository;
 import org.cardanofoundation.explorer.api.repository.PoolInfoCheckpointRepository;
 import org.springframework.beans.factory.annotation.Value;
@@ -31,12 +32,17 @@ public class FetchRewardDataFromKoiosServiceImpl implements FetchRewardDataServi
   @Value("${application.api.check-pool-info.base-url}")
   private String apiCheckPoolInfoUrl;
 
+  @Value("${application.api.check-epoch-stake.base-url}")
+  private String apiCheckEpochStakeUrl;
+
   private final RestTemplate restTemplate;
   private final RewardCheckpointRepository rewardCheckpointRepository;
 
   private final PoolHistoryCheckpointRepository poolHistoryCheckpointRepository;
 
   private final PoolInfoCheckpointRepository poolInfoCheckpointRepository;
+
+  private final EpochStakeCheckpointRepository epochStakeCheckpointRepository;
 
   @Override
   public boolean checkRewardAvailable(String stakeKey) {
@@ -92,6 +98,20 @@ public class FetchRewardDataFromKoiosServiceImpl implements FetchRewardDataServi
       i++;
     }
     return isFetch;
+  }
+
+  @Override
+  public Boolean checkEpochStakeForPool(List<String> rewardAccounts) {
+    Integer countCheckPoint = epochStakeCheckpointRepository.checkEpochStakeByAccountsAndEpoch(
+        rewardAccounts);
+    Integer sizeCheck = rewardAccounts.size();
+    return Objects.equals(countCheckPoint, sizeCheck);
+  }
+
+  @Override
+  public Boolean fetchEpochStakeForPool(List<String> rewardAccounts) {
+    return restTemplate.postForObject(apiCheckEpochStakeUrl, rewardAccounts,
+        Boolean.class);
   }
 
   @Override

--- a/src/main/java/org/cardanofoundation/explorer/api/service/impl/FetchRewardDataServiceImpl.java
+++ b/src/main/java/org/cardanofoundation/explorer/api/service/impl/FetchRewardDataServiceImpl.java
@@ -55,6 +55,16 @@ public class FetchRewardDataServiceImpl implements FetchRewardDataService {
   }
 
   @Override
+  public Boolean checkEpochStakeForPool(List<String> rewardAccounts) {
+    return true;
+  }
+
+  @Override
+  public Boolean fetchEpochStakeForPool(List<String> rewardAccounts) {
+    return true;
+  }
+
+  @Override
   public Boolean isKoiOs() {
     return false;
   }

--- a/src/main/resources/config/application-dev.yaml
+++ b/src/main/resources/config/application-dev.yaml
@@ -95,6 +95,8 @@ application:
       base-url: ${API_CHECK_POOL_HISTORY_URL:http://10.4.10.231:8888/api/v1/pool-history/fetch}
     check-pool-info:
       base-url: ${API_CHECK_POOL_INFO_URL:http://10.4.10.231:8888/api/v1/pool-info/fetch}
+    check-epoch-stake:
+      base-url: ${API_CHECK_EPOCH_STAKE_URL:http://10.4.10.231:8888/api/v1/epoch-stake/fetch}
 
 cloud:
   aws:

--- a/src/main/resources/config/application-local.yaml
+++ b/src/main/resources/config/application-local.yaml
@@ -98,7 +98,8 @@ application:
       base-url: ${API_CHECK_POOL_HISTORY_URL:http://10.4.10.231:8888/api/v1/pool-history/fetch}
     check-pool-info:
       base-url: ${API_CHECK_POOL_INFO_URL:http://10.4.10.231:8888/api/v1/pool-info/fetch}
-
+    check-epoch-stake:
+      base-url: ${API_CHECK_EPOCH_STAKE_URL:http://10.4.10.231:8888/api/v1/epoch-stake/fetch}
 rsa:
   key:
     path: /key/public_key

--- a/src/main/resources/config/application-prod.yaml
+++ b/src/main/resources/config/application-prod.yaml
@@ -75,6 +75,8 @@ application:
       base-url: ${API_CHECK_POOL_HISTORY_URL:http://10.4.10.231:8888/api/v1/pool-history/fetch}
     check-pool-info:
       base-url: ${API_CHECK_POOL_INFO_URL:http://10.4.10.231:8888/api/v1/pool-info/fetch}
+    check-epoch-stake:
+      base-url: ${API_CHECK_EPOCH_STAKE_URL:http://10.4.10.231:8888/api/v1/epoch-stake/fetch}
 
 cloud:
   aws:

--- a/src/main/resources/config/application-test.yaml
+++ b/src/main/resources/config/application-test.yaml
@@ -75,6 +75,8 @@ application:
       base-url: ${API_CHECK_POOL_HISTORY_URL:http://10.4.10.231:8888/api/v1/pool-history/fetch}
     check-pool-info:
       base-url: ${API_CHECK_POOL_INFO_URL:http://10.4.10.231:8888/api/v1/pool-info/fetch}
+    check-epoch-stake:
+      base-url: ${API_CHECK_EPOCH_STAKE_URL:http://10.4.10.231:8888/api/v1/epoch-stake/fetch}
 
 cloud:
   aws:


### PR DESCRIPTION
## Subject

- get stake from koi-os by stake address in pool detail

## Changes Description

-  API: /api/v1/delegations/pool-detail-delegators
- Change logic check epoch_stake, epoch_stake_checkpoint to view total value

## How to test

- API URL: {{baseUrl}}/api/v1/delegations/pool-detail-delegators?poolView=pool1fr8ug253hlv0pt4sxu3w20r03pnpkh2wpedegp55t8nsx28rkma&page=0&size=50

## Evident for results

- 

## Referenced Ticket

- https://jira.sotatek.com/projects/ADAE/issues/ADAE-463?filter=myopenissues
