### PR TITLE
fix: change code after change db, get delegators incorrect

### DIFF
--- a/src/main/java/org/cardanofoundation/explorer/api/repository/PoolHistoryCheckpointRepository.java
+++ b/src/main/java/org/cardanofoundation/explorer/api/repository/PoolHistoryCheckpointRepository.java
@@ -11,8 +11,16 @@ import org.springframework.stereotype.Repository;
 public interface PoolHistoryCheckpointRepository extends
     JpaRepository<PoolHistoryCheckpoint, Long> {
 
-  @Query("SELECT COUNT(cp.id) FROM PoolHistoryCheckpoint cp "
-      + "WHERE cp.view IN :poolViews AND cp.epochCheckpoint = "
-      + "(SELECT max(e.no) - 1 FROM Epoch e) AND cp.earnedReward = TRUE")
+  @Query(value =
+      "SELECT COUNT(cp.id) FROM PoolHistoryCheckpoint cp "
+          + "WHERE cp.view IN :poolViews AND cp.epochCheckpoint = "
+          + "(SELECT max(e.no) - 1 FROM Epoch e) AND cp.isSpendableReward = TRUE")
   Integer checkRewardByPoolViewAndEpoch(@Param("poolViews") Set<String> poolViews);
+
+  @Query(value =
+      "SELECT ph.view FROM PoolHash ph WHERE ph.view NOT IN ( "
+          + "SELECT pc.view FROM PoolHistoryCheckpoint pc "
+          + "WHERE pc.epochCheckpoint = (SELECT max(e.no) - 1 FROM Epoch e) AND pc.isSpendableReward = TRUE AND pc.view IN :poolViews ) "
+          + "AND ph.view IN :poolViews ")
+  Set<String> checkPoolHistoryByPoolViewAndEpoch(@Param("poolViews") Set<String> poolViews);
 }

--- a/src/main/java/org/cardanofoundation/explorer/api/repository/PoolHistoryRepository.java
+++ b/src/main/java/org/cardanofoundation/explorer/api/repository/PoolHistoryRepository.java
@@ -16,32 +16,32 @@ import org.springframework.stereotype.Repository;
 public interface PoolHistoryRepository extends JpaRepository<PoolHistory, Long> {
 
   @Query(value =
-      "SELECT ph.poolId AS view, CAST(ph.delegRewards AS BigInteger) AS delegateReward, ph.epochRos AS ros "
+      "SELECT ph.pool.view AS view, ph.delegatorRewards AS delegateReward, ph.epochRos AS ros "
           + "FROM PoolHistory ph "
-          + "WHERE ph.poolId IN :poolIds AND ph.epochNo = :epochNo")
+          + "WHERE ph.pool.view IN :poolIds AND ph.epochNo = :epochNo")
   List<PoolHistoryKoiosProjection> getPoolHistoryKoiOs(@Param("poolIds") Set<String> poolIds,
       @Param("epochNo") Integer epochNo);
 
   @Query(value =
-      "SELECT ph.epochNo AS epochNo, CAST(ph.delegRewards AS BigInteger) AS delegateReward, ph.epochRos AS ros, "
-          + "CAST(ph.activeStake AS BigInteger) AS activeStake, CAST(ph.poolFees AS BigInteger) AS poolFees "
+      "SELECT ph.epochNo AS epochNo, ph.delegatorRewards AS delegateReward, ph.epochRos AS ros, "
+          + "ph.activeStake AS activeStake, ph.poolFees AS poolFees "
           + "FROM PoolHistory ph "
-          + "WHERE ph.poolId = :poolId "
+          + "WHERE ph.pool.view = :poolId "
           + "ORDER BY ph.epochNo DESC")
   Page<PoolHistoryKoiosProjection> getPoolHistoryKoiOs(@Param("poolId") String poolId, Pageable pageable);
 
   @Query(value =
-          "SELECT ph.epochNo AS epochNo, CAST(ph.delegRewards AS BigInteger) AS delegateReward, ph.epochRos AS ros, "
-                  + "CAST(ph.activeStake AS BigInteger) AS activeStake, CAST(ph.poolFees AS BigInteger) AS poolFees "
+          "SELECT ph.epochNo AS epochNo, ph.delegatorRewards AS delegateReward, ph.epochRos AS ros, "
+                  + "ph.activeStake AS activeStake, ph.poolFees AS poolFees "
                   + "FROM PoolHistory ph "
-                  + "WHERE ph.poolId = :poolId "
+                  + "WHERE ph.pool.view = :poolId "
                   + "ORDER BY ph.epochNo DESC")
   List<PoolHistoryKoiosProjection> getPoolHistoryKoiOs(@Param("poolId") String poolId);
 
   @Query(value =
-      "SELECT ph.epochNo AS chartKey, CAST(ph.activeStake AS BigInteger) AS chartValue "
+      "SELECT ph.epochNo AS chartKey, ph.activeStake AS chartValue "
           + "FROM PoolHistory ph "
-          + "WHERE ph.poolId = :poolId "
+          + "WHERE ph.pool.view = :poolId "
           + "ORDER BY ph.epochNo ASC")
   List<EpochChartProjection> getPoolHistoryKoiOsForEpochChart(@Param("poolId") String poolId);
 }

--- a/src/main/java/org/cardanofoundation/explorer/api/repository/PoolInfoRepository.java
+++ b/src/main/java/org/cardanofoundation/explorer/api/repository/PoolInfoRepository.java
@@ -14,28 +14,29 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface PoolInfoRepository extends JpaRepository<PoolInfo, Long> {
 
-  @Query(value = "SELECT SUM(CAST(pi.liveStake AS BigInteger)) FROM PoolInfo pi WHERE pi.fetchedAtEpoch = :epochNo")
+  @Query(value = "SELECT SUM(pi.liveStake) FROM PoolInfo pi WHERE pi.fetchedAtEpoch = :epochNo")
   BigInteger getTotalLiveStake(@Param("epochNo") Integer epochNo);
 
   @Query(value =
-      "SELECT pi.poolId AS view, CAST(pi.activeStake AS BigInteger) AS activeStake, pi.liveSaturation AS saturation "
+      "SELECT pi.pool.view AS view, pi.activeStake AS activeStake, pi.liveSaturation AS saturation "
           + "FROM PoolInfo pi "
-          + "WHERE pi.poolId IN :poolIds AND pi.fetchedAtEpoch = :epochNo")
+          + "WHERE pi.pool.view IN :poolIds AND pi.fetchedAtEpoch = :epochNo")
   List<PoolInfoKoiosProjection> getPoolInfoKoiOs(@Param("poolIds") Set<String> poolIds,
       @Param("epochNo") Integer epochNo);
 
-  @Query(value = "SELECT pi.poolId AS view, CAST(pi.activeStake AS BigInteger) AS activeStake "
-      + "FROM PoolInfo pi "
-      + "WHERE pi.fetchedAtEpoch = :epochNo AND pi.activeStake IS NOT NULL "
-      + "ORDER BY CAST(pi.activeStake AS BigInteger) DESC")
+  @Query(value =
+      "SELECT pi.pool.view AS view, pi.activeStake AS activeStake "
+          + "FROM PoolInfo pi "
+          + "WHERE pi.fetchedAtEpoch = :epochNo AND pi.activeStake IS NOT NULL "
+          + "ORDER BY pi.activeStake DESC")
   List<PoolInfoKoiosProjection> getTopPoolInfoKoiOs(@Param("epochNo") Integer epochNo,
       Pageable pageable);
 
-  @Query(value = "SELECT CAST(pi.activeStake AS BigInteger) FROM PoolInfo pi "
-      + "WHERE pi.poolId = :poolId AND pi.fetchedAtEpoch = :epochNo")
+  @Query(value = "SELECT pi.activeStake FROM PoolInfo pi "
+      + "WHERE pi.pool.view = :poolId AND pi.fetchedAtEpoch = :epochNo")
   BigInteger getActiveStakeByPoolAndEpoch(@Param("poolId") String poolId,
       @Param("epochNo") Integer epochNo);
 
-  @Query(value = "SELECT SUM(CAST(pi.activeStake AS BigInteger)) FROM PoolInfo pi WHERE pi.fetchedAtEpoch = :epochNo")
+  @Query(value = "SELECT SUM(pi.activeStake) FROM PoolInfo pi WHERE pi.fetchedAtEpoch = :epochNo")
   BigInteger getTotalActiveStake(@Param("epochNo") Integer epochNo);
 }

--- a/src/main/java/org/cardanofoundation/explorer/api/service/FetchRewardDataService.java
+++ b/src/main/java/org/cardanofoundation/explorer/api/service/FetchRewardDataService.java
@@ -11,6 +11,8 @@ public interface FetchRewardDataService {
 
   Boolean checkPoolHistoryForPool(Set<String> poolIds);
 
+  Set<String> checkAllPoolHistoryForPool(Set<String> poolIds);
+
   Boolean fetchPoolHistoryForPool(Set<String> poolIds);
 
   Boolean checkPoolInfoForPool(Set<String> poolIds);

--- a/src/main/java/org/cardanofoundation/explorer/api/service/impl/DelegationServiceImpl.java
+++ b/src/main/java/org/cardanofoundation/explorer/api/service/impl/DelegationServiceImpl.java
@@ -151,8 +151,7 @@ public class DelegationServiceImpl implements DelegationService {
     if (Objects.nonNull(search) && search.isBlank()) {
       search = null;
     }
-    Page<PoolListProjection> poolIdPage = poolHashRepository.findAllByPoolViewAndPoolName(search,
-        search, pageable);
+    Page<PoolListProjection> poolIdPage = poolHashRepository.findAllByPoolViewAndPoolName(search, pageable);
     List<PoolResponse> poolList = new ArrayList<>();
     Set<Long> poolIds = new HashSet<>();
     List<Object> poolViews = new ArrayList<>();

--- a/src/main/java/org/cardanofoundation/explorer/api/service/impl/FetchRewardDataFromKoiosServiceImpl.java
+++ b/src/main/java/org/cardanofoundation/explorer/api/service/impl/FetchRewardDataFromKoiosServiceImpl.java
@@ -61,6 +61,11 @@ public class FetchRewardDataFromKoiosServiceImpl implements FetchRewardDataServi
   }
 
   @Override
+  public Set<String> checkAllPoolHistoryForPool(Set<String> poolIds) {
+    return poolHistoryCheckpointRepository.checkPoolHistoryByPoolViewAndEpoch(poolIds);
+  }
+
+  @Override
   public Boolean fetchPoolHistoryForPool(Set<String> poolIds) {
     int i = 0;
     boolean isFetch = false;

--- a/src/main/java/org/cardanofoundation/explorer/api/service/impl/FetchRewardDataServiceImpl.java
+++ b/src/main/java/org/cardanofoundation/explorer/api/service/impl/FetchRewardDataServiceImpl.java
@@ -29,6 +29,11 @@ public class FetchRewardDataServiceImpl implements FetchRewardDataService {
   }
 
   @Override
+  public Set<String> checkAllPoolHistoryForPool(Set<String> poolIds) {
+    return new HashSet<>();
+  }
+
+  @Override
   public Boolean checkPoolInfoForPool(Set<String> poolIds) {
     return true;
   }


### PR DESCRIPTION
## Subject

- update code after change db(pool_history, pool_history_checkpoint, pool_info)
- get delegators number incorrect
## Changes Description

- 

## How to test

- /api/v1/delegations/pool-list
- /api/v1/delegations/top
- /api/v1/delegations/header

## Evident for results

-

## Referenced Ticket

- https://jira.sotatek.com/projects/ADAE/issues/ADAE-499?filter=myopenissues
