### PR TITLE
feat: [MET-1139] add logic optimize chart token

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <version.lombok-mapstruct-binding>0.2.0</version.lombok-mapstruct-binding>
         <version.ledgersync-common>0.1.0</version.ledgersync-common>
         <version.explorer-common>0.1.1-SNAPSHOT</version.explorer-common>
-        <version.explorer-consumer-common>0.1.4</version.explorer-consumer-common>
+        <version.explorer-consumer-common>0.1.5-SNAPSHOT</version.explorer-consumer-common>
         <sonar.coverage.jacoco.xmlReportPaths>../cardano-explorer-api/target/site/jacoco-aggregate/jacoco.xml
         </sonar.coverage.jacoco.xmlReportPaths>
         <sonar.coverage.exclusions>**/entity/*, **/validation/*</sonar.coverage.exclusions>

--- a/src/main/java/org/cardanofoundation/explorer/api/controller/TokenController.java
+++ b/src/main/java/org/cardanofoundation/explorer/api/controller/TokenController.java
@@ -1,5 +1,6 @@
 package org.cardanofoundation.explorer.api.controller;
 
+import java.util.concurrent.ExecutionException;
 import org.cardanofoundation.explorer.api.common.enumeration.AnalyticType;
 import org.cardanofoundation.explorer.api.config.LogMessage;
 import org.cardanofoundation.explorer.api.model.response.BaseFilterResponse;
@@ -76,7 +77,8 @@ public class TokenController {
   @Operation(summary = "Filter transaction by token")
   public ResponseEntity<List<TokenVolumeAnalyticsResponse>> getTokenVolumeAnalytics(
       @PathVariable String tokenId, @PathVariable
-      @Parameter(description = "Type analytics: 1d, 1w, 1m, 3m") AnalyticType type) {
+      @Parameter(description = "Type analytics: 1d, 1w, 1m, 3m") AnalyticType type)
+      throws ExecutionException, InterruptedException {
     return ResponseEntity.ok(tokenService.getTokenVolumeAnalytic(tokenId, type));
   }
 }

--- a/src/main/java/org/cardanofoundation/explorer/api/model/response/token/TokenVolumeAnalyticsResponse.java
+++ b/src/main/java/org/cardanofoundation/explorer/api/model/response/token/TokenVolumeAnalyticsResponse.java
@@ -2,11 +2,13 @@ package org.cardanofoundation.explorer.api.model.response.token;
 
 import java.math.BigInteger;
 import java.time.LocalDate;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
+@AllArgsConstructor
 public class TokenVolumeAnalyticsResponse {
   private LocalDate date;
   private BigInteger value;

--- a/src/main/java/org/cardanofoundation/explorer/api/repository/AggregateAddressTokenRepository.java
+++ b/src/main/java/org/cardanofoundation/explorer/api/repository/AggregateAddressTokenRepository.java
@@ -1,0 +1,20 @@
+package org.cardanofoundation.explorer.api.repository;
+
+import java.math.BigInteger;
+import java.time.LocalDate;
+import java.util.Optional;
+import org.cardanofoundation.explorer.consumercommon.entity.aggregation.AggregateAddressToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface AggregateAddressTokenRepository extends JpaRepository<AggregateAddressToken, Long> {
+
+  @Query(value = "SELECT sum(aggAddr.balance) "
+      + " FROM AggregateAddressToken aggAddr "
+      + " WHERE aggAddr.ident = :multiAsset "
+      + " AND aggAddr.day > :from and aggAddr.day <= :to ")
+  Optional<BigInteger> sumBalanceInTimeRange(@Param("multiAsset") Long multiAssetId,
+                                             @Param("from") LocalDate from,
+                                             @Param("to") LocalDate to);
+}

--- a/src/main/java/org/cardanofoundation/explorer/api/service/TokenService.java
+++ b/src/main/java/org/cardanofoundation/explorer/api/service/TokenService.java
@@ -1,5 +1,6 @@
 package org.cardanofoundation.explorer.api.service;
 
+import java.util.concurrent.ExecutionException;
 import org.cardanofoundation.explorer.api.common.enumeration.AnalyticType;
 import org.cardanofoundation.explorer.api.model.response.BaseFilterResponse;
 import org.cardanofoundation.explorer.api.model.response.token.*;
@@ -51,5 +52,6 @@ public interface TokenService {
    * @param type type of analytic
    * @return list analytic volume of token
    */
-  List<TokenVolumeAnalyticsResponse> getTokenVolumeAnalytic(String tokenId, AnalyticType type);
+  List<TokenVolumeAnalyticsResponse> getTokenVolumeAnalytic(String tokenId, AnalyticType type)
+      throws ExecutionException, InterruptedException;
 }


### PR DESCRIPTION
## Subject

- MET-1139: Optimize Chart Token Volume

## Changes Description

- Change logic selecting data from table address_token to table agg_address_token (which stores calculated data) for better peformance

## How to test

- Need to merge the common PR firstly for entities of agg tables
- Run project and then run this with postman: /api/v1/tokens/analytics/:tokenId/:typeAnalytic
 + ex: localhost:8080/api/v1/tokens/analytics/asset17q7r59zlc3dgw0venc80pdv566q6yguw03f0d9/THREE_MONTH

## Evident for results

![image](https://github.com/cardano-foundation/cf-explorer-api/assets/132549582/25e16cf8-e639-4c20-a763-d8de8fb9eea2)


## Referenced Ticket

- https://cardanofoundation.atlassian.net/browse/MET-1139