### PR TITLE
feat: [MET-1199] Optimize chart for stake/address balance

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <version.lombok-mapstruct-binding>0.2.0</version.lombok-mapstruct-binding>
         <version.ledgersync-common>0.1.0</version.ledgersync-common>
         <version.explorer-common>0.1.1-SNAPSHOT</version.explorer-common>
-        <version.explorer-consumer-common>0.1.4</version.explorer-consumer-common>
+        <version.explorer-consumer-common>0.1.5-SNAPSHOT</version.explorer-consumer-common>
         <sonar.coverage.jacoco.xmlReportPaths>../cardano-explorer-api/target/site/jacoco-aggregate/jacoco.xml
         </sonar.coverage.jacoco.xmlReportPaths>
         <sonar.coverage.exclusions>**/entity/*, **/validation/*</sonar.coverage.exclusions>

--- a/src/main/java/org/cardanofoundation/explorer/api/controller/StakeKeyController.java
+++ b/src/main/java/org/cardanofoundation/explorer/api/controller/StakeKeyController.java
@@ -157,8 +157,8 @@ public class StakeKeyController {
   @GetMapping("/min-max-balance/{stakeKey}")
   @LogMessage
   @Operation(summary = "Get the highest and lowest balance address")
-  public ResponseEntity<List<BigInteger>> getAddressMinMaxBalance(@PathVariable String stakeKey) {
-    return ResponseEntity.ok(stakeService.getAddressMinMaxBalance(stakeKey));
+  public ResponseEntity<List<BigInteger>> getStakeMinMaxBalance(@PathVariable String stakeKey) {
+    return ResponseEntity.ok(stakeService.getStakeMinMaxBalance(stakeKey));
   }
 
 }

--- a/src/main/java/org/cardanofoundation/explorer/api/projection/MinMaxProjection.java
+++ b/src/main/java/org/cardanofoundation/explorer/api/projection/MinMaxProjection.java
@@ -1,0 +1,12 @@
+package org.cardanofoundation.explorer.api.projection;
+
+import java.math.BigInteger;
+
+public interface MinMaxProjection {
+
+  BigInteger getMinVal();
+
+  BigInteger getMaxVal();
+
+  Long getMaxTxId();
+}

--- a/src/main/java/org/cardanofoundation/explorer/api/service/StakeKeyService.java
+++ b/src/main/java/org/cardanofoundation/explorer/api/service/StakeKeyService.java
@@ -127,5 +127,5 @@ public interface StakeKeyService {
    * @param stakeKey stake address
    * @return min and max balance of stake address
    */
-  List<BigInteger> getAddressMinMaxBalance(String stakeKey);
+  List<BigInteger> getStakeMinMaxBalance(String stakeKey);
 }

--- a/src/main/java/org/cardanofoundation/explorer/api/service/impl/AddressServiceImpl.java
+++ b/src/main/java/org/cardanofoundation/explorer/api/service/impl/AddressServiceImpl.java
@@ -1,6 +1,7 @@
 package org.cardanofoundation.explorer.api.service.impl;
 
 import com.bloxbean.cardano.client.transaction.spec.script.NativeScript;
+import java.util.Collections;
 import org.apache.commons.codec.binary.Hex;
 import org.cardanofoundation.explorer.api.common.constant.CommonConstant;
 import org.cardanofoundation.explorer.api.common.enumeration.AnalyticType;
@@ -16,6 +17,7 @@ import org.cardanofoundation.explorer.api.model.response.address.AddressResponse
 import org.cardanofoundation.explorer.api.model.response.contract.ContractFilterResponse;
 import org.cardanofoundation.explorer.api.model.response.token.TokenAddressResponse;
 import org.cardanofoundation.explorer.api.projection.AddressTokenProjection;
+import org.cardanofoundation.explorer.api.projection.MinMaxProjection;
 import org.cardanofoundation.explorer.api.repository.AddressTokenBalanceRepository;
 import org.cardanofoundation.explorer.api.repository.AddressRepository;
 import org.cardanofoundation.explorer.api.repository.AddressTxBalanceRepository;
@@ -163,28 +165,16 @@ public class AddressServiceImpl implements AddressService {
   @Override
   @Transactional(readOnly = true)
   public List<BigInteger> getAddressMinMaxBalance(String address) {
-    Address addr = addressRepository.findFirstByAddress(address).orElseThrow(
-        () -> new BusinessException(BusinessCode.ADDRESS_NOT_FOUND));
-    List<BigInteger> balanceList = addressTxBalanceRepository.findAllByAddress(addr);
-    if(balanceList.isEmpty()) {
-      return new ArrayList<>();
-    }
-    BigInteger maxBalance = balanceList.get(0);
-    BigInteger minBalance = balanceList.get(0);
-    BigInteger sumBalance = balanceList.get(0);
-    balanceList.remove(0);
-    for(BigInteger balance : balanceList) {
-      sumBalance = sumBalance.add(balance);
-      if(sumBalance.compareTo(maxBalance) > 0) {
-        maxBalance = sumBalance;
-      }
-      if(sumBalance.compareTo(minBalance) < 0) {
-        minBalance = sumBalance;
-      }
-    }
-    return Arrays.asList(minBalance, maxBalance);
-  }
+    Address addr = addressRepository.findFirstByAddress(address)
+        .orElseThrow(() -> new BusinessException(BusinessCode.ADDRESS_NOT_FOUND));
 
+    MinMaxProjection balanceList = addressTxBalanceRepository.findMinMaxBalanceByAddress(
+        addr.getId());
+    if (balanceList == null) {
+      return Collections.emptyList();
+    }
+    return List.of(balanceList.getMinVal(), balanceList.getMaxVal());
+  }
 
   @Override
   @Transactional(readOnly = true)


### PR DESCRIPTION
## Subject

- Optimize APIs: stake min max balance + Payment address minmax balance.

## Changes Description

- Optimize SQL query, calculate min/max from database instead of get all data from database and calculate in code.
- Add new index to table **address_tx_balance**:
create index address_tx_balance_stake_address_id_tx_id_balance_idx
    on mainnet.address_tx_balance (stake_address_id, tx_id, balance);

## How to test

- Run these 2 APIs
- /api/v1/stakes/min-max-balance/{stakeKey}
- /api/v1/addresses/min-max-balance/{address}

## Evident for results

![image](https://github.com/cardano-foundation/cf-explorer-api/assets/132549582/008a5bbe-81f6-408e-82ce-7135c980c3a5)

![image](https://github.com/cardano-foundation/cf-explorer-api/assets/132549582/145a9b51-3739-41cf-9655-2b7a922d684c)


## Referenced Ticket

- https://cardanofoundation.atlassian.net/browse/MET-1199
