### PR TITLE
update logic query data token balance

### DIFF
--- a/src/main/java/org/cardanofoundation/explorer/api/repository/AddressTokenRepository.java
+++ b/src/main/java/org/cardanofoundation/explorer/api/repository/AddressTokenRepository.java
@@ -41,8 +41,8 @@ public interface AddressTokenRepository extends JpaRepository<AddressToken, Long
       + "     (SELECT MAX(block.id) FROM Block block WHERE block.time < :to AND block.txCount > 0)"
       + "   )"
       + " AND addrToken.balance > 0")
-  BigInteger sumBalanceBetweenTx(@Param("multiAsset") MultiAsset multiAsset,
-                                 @Param("from") Timestamp from, @Param("to") Timestamp to);
+  Optional<BigInteger> sumBalanceBetweenTx(@Param("multiAsset") MultiAsset multiAsset,
+                                           @Param("from") Timestamp from, @Param("to") Timestamp to);
 
   @Query(value = "SELECT COALESCE(SUM(addrToken.balance), 0)"
       + " FROM AddressToken addrToken"

--- a/src/main/java/org/cardanofoundation/explorer/api/repository/AggregateAddressTokenRepository.java
+++ b/src/main/java/org/cardanofoundation/explorer/api/repository/AggregateAddressTokenRepository.java
@@ -17,4 +17,7 @@ public interface AggregateAddressTokenRepository extends JpaRepository<Aggregate
   Optional<BigInteger> sumBalanceInTimeRange(@Param("multiAsset") Long multiAssetId,
                                              @Param("from") LocalDate from,
                                              @Param("to") LocalDate to);
+
+  @Query("select max(a.day) from AggregateAddressToken a")
+  Optional<LocalDate> getMaxDay();
 }


### PR DESCRIPTION
## Subject

- update logic query data token balance to handler case data interrupted when consumer stopped

## Changes Description

- update logic query data with max agg day and check if missing agg data => will select data from table address_token_balance

## How to test

- Start application locally and run API: localhost:8080/api/v1/tokens/analytics/asset17q7r59zlc3dgw0venc80pdv566q6yguw03f0d9/ONE_DAY

## Evident for results

- ![image](https://github.com/cardano-foundation/cf-explorer-api/assets/132533424/b8d38e83-e68c-42c2-939f-1f8b98075300)

## Referenced Ticket

- https://cardanofoundation.atlassian.net/browse/MET-1139
