### PR TITLE
feat:[MET-1154] add logic check cache TokenPage from scheduler firstly

### DIFF
--- a/src/main/java/org/cardanofoundation/explorer/api/common/enumeration/RedisKey.java
+++ b/src/main/java/org/cardanofoundation/explorer/api/common/enumeration/RedisKey.java
@@ -1,5 +1,5 @@
 package org.cardanofoundation.explorer.api.common.enumeration;
 
 public enum RedisKey {
-    REDIS_TOP_STAKE_DELEGATORS
+    REDIS_TOP_STAKE_DELEGATORS, REDIS_TOKEN_PAGE
 }

--- a/src/main/java/org/cardanofoundation/explorer/api/service/cache/TokenPageCacheService.java
+++ b/src/main/java/org/cardanofoundation/explorer/api/service/cache/TokenPageCacheService.java
@@ -1,0 +1,17 @@
+package org.cardanofoundation.explorer.api.service.cache;
+
+import org.cardanofoundation.explorer.api.model.response.BaseFilterResponse;
+import org.cardanofoundation.explorer.api.model.response.token.TokenFilterResponse;
+import org.springframework.data.domain.Pageable;
+
+import java.util.Optional;
+
+public interface TokenPageCacheService {
+
+  /**
+   * get token filter response from cache scheduler
+   *
+   * @return page token response;
+   */
+  Optional<BaseFilterResponse<TokenFilterResponse>> getTokePageCache(Pageable pageable);
+}

--- a/src/main/java/org/cardanofoundation/explorer/api/service/impl/TokenServiceImpl.java
+++ b/src/main/java/org/cardanofoundation/explorer/api/service/impl/TokenServiceImpl.java
@@ -5,6 +5,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+
 import org.cardanofoundation.explorer.api.common.enumeration.AnalyticType;
 import org.cardanofoundation.explorer.api.common.enumeration.TypeTokenGson;
 import org.cardanofoundation.explorer.api.config.aop.singletoncache.SingletonCall;
@@ -17,6 +18,7 @@ import org.cardanofoundation.explorer.api.model.response.token.*;
 import org.cardanofoundation.explorer.api.projection.AddressTokenProjection;
 import org.cardanofoundation.explorer.api.repository.*;
 import org.cardanofoundation.explorer.api.service.TokenService;
+import org.cardanofoundation.explorer.api.service.cache.TokenPageCacheService;
 import org.cardanofoundation.explorer.api.util.StreamUtil;
 import org.cardanofoundation.explorer.consumercommon.entity.Address;
 import org.cardanofoundation.explorer.consumercommon.entity.AssetMetadata;
@@ -25,6 +27,7 @@ import org.cardanofoundation.explorer.consumercommon.entity.MultiAsset;
 import org.cardanofoundation.explorer.common.exceptions.BusinessException;
 import org.cardanofoundation.explorer.api.projection.TokenVolumeProjection;
 import org.cardanofoundation.explorer.api.projection.TokenNumberHoldersProjection;
+
 import java.math.BigInteger;
 import java.sql.Timestamp;
 import java.time.Instant;
@@ -34,6 +37,7 @@ import java.time.LocalTime;
 import java.time.ZoneOffset;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -60,18 +64,24 @@ public class TokenServiceImpl implements TokenService {
   private final MaTxMintMapper maTxMintMapper;
   private final AssetMetadataMapper assetMetadataMapper;
   private final AggregateAddressTokenRepository aggregateAddressTokenRepository;
+  private final TokenPageCacheService tokenPageCacheService;
 
   @Qualifier("taskExecutor")
   private final TaskExecutor taskExecutor;
 
   static final Integer TOKEN_VOLUME_ANALYTIC_NUMBER = 5;
 
-
-  @SingletonCall(typeToken = TypeTokenGson.TOKEN_FILTER, expireAfterSeconds = 200)
+  @SingletonCall(typeToken = TypeTokenGson.TOKEN_FILTER, expireAfterSeconds = 150, callAfterMilis = 200)
   @Override
   @Transactional(readOnly = true)
   public BaseFilterResponse<TokenFilterResponse> filterToken(Pageable pageable)
       throws ExecutionException, InterruptedException {
+    Optional<BaseFilterResponse<TokenFilterResponse>> cacheResp =
+        tokenPageCacheService.getTokePageCache(pageable);
+    if (cacheResp.isPresent()){
+      return cacheResp.get();
+    }
+
     Page<MultiAsset> multiAssets = multiAssetRepository.findAll(pageable);
     Set<String> subjects = StreamUtil.mapApplySet(multiAssets.getContent(), ma -> ma.getPolicy() + ma.getName());
 

--- a/src/main/java/org/cardanofoundation/explorer/api/service/impl/cache/TokenPageCacheServiceImpl.java
+++ b/src/main/java/org/cardanofoundation/explorer/api/service/impl/cache/TokenPageCacheServiceImpl.java
@@ -1,0 +1,74 @@
+package org.cardanofoundation.explorer.api.service.impl.cache;
+
+import com.google.gson.*;
+import com.google.gson.reflect.TypeToken;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.cardanofoundation.explorer.api.common.enumeration.RedisKey;
+import org.cardanofoundation.explorer.api.model.response.BaseFilterResponse;
+import org.cardanofoundation.explorer.api.model.response.token.TokenFilterResponse;
+import org.cardanofoundation.explorer.api.service.cache.TokenPageCacheService;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class TokenPageCacheServiceImpl implements TokenPageCacheService {
+  private final RedisTemplate<String, Object> redisTemplate;
+
+  @Value("${application.network}")
+  private String network;
+
+  private static final Gson GSON = new GsonBuilder()
+      .registerTypeAdapter(LocalDate.class,
+          (JsonSerializer<LocalDate>) (value, type, context) ->
+              new JsonPrimitive(value.format(DateTimeFormatter.ISO_LOCAL_DATE))
+      )
+      .registerTypeAdapter(LocalDateTime.class,
+          (JsonSerializer<LocalDateTime>) (value, type, context) ->
+              new JsonPrimitive(value.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME))
+      )
+      .registerTypeAdapter(LocalDate.class,
+          (JsonDeserializer<LocalDate>) (jsonElement, type, context) ->
+              LocalDate.parse(
+                  jsonElement.getAsJsonPrimitive().getAsString(),
+                  DateTimeFormatter.ISO_LOCAL_DATE
+              )
+      )
+      .registerTypeAdapter(LocalDateTime.class,
+          (JsonDeserializer<LocalDateTime>) (jsonElement, type, context) ->
+              LocalDateTime.parse(
+                  jsonElement.getAsJsonPrimitive().getAsString(),
+                  DateTimeFormatter.ISO_LOCAL_DATE_TIME
+              )
+      )
+      .create();
+
+  @Override
+  public Optional<BaseFilterResponse<TokenFilterResponse>> getTokePageCache(Pageable pageable) {
+    String redisKey = RedisKey.REDIS_TOKEN_PAGE.name() + ":" + network + ":" + toStr(pageable);
+    Object cacheData = redisTemplate.opsForValue().get(redisKey);
+    if (cacheData == null) {
+      return Optional.empty();
+    }
+    try {
+      return Optional.of(GSON.fromJson(cacheData.toString(), new TypeToken<BaseFilterResponse<TokenFilterResponse>>() {
+      }.getType()));
+    } catch (Exception e) {
+      log.error("Exception when getTokenFilterResponseSchedulerCache key: {}", redisKey, e);
+      return Optional.empty();
+    }
+  }
+
+  private String toStr(Pageable pageable) {
+    return pageable.toString().replace(" ", "").replace(":", "_");
+  }
+}


### PR DESCRIPTION
## Subject

- Add get cache date from scheduler for first Token Page request

## Changes Description

- add TokenPageService and logic get cache data in method filterToken

## How to test

- Run locally and call API:
localhost:8080/api/v1/tokens?page=1&size=50&sort=txCount%2CDESC

## Evident for results

- ![image](https://github.com/cardano-foundation/cf-explorer-api/assets/132533424/70f16f6f-7aac-424e-a1c5-69c67eccdb3e)
- 
![image](https://github.com/cardano-foundation/cf-explorer-api/assets/132533424/baee67c8-1a1c-4a86-8771-aa50033ea89b)


## Referenced Ticket

- https://cardanofoundation.atlassian.net/browse/MET-1154
