### PR TITLE
Fix: update API responses for improved coherence and logical consistency

### DIFF
--- a/src/main/java/org/cardanofoundation/explorer/api/controller/AddressController.java
+++ b/src/main/java/org/cardanofoundation/explorer/api/controller/AddressController.java
@@ -3,6 +3,7 @@ package org.cardanofoundation.explorer.api.controller;
 import java.util.concurrent.ExecutionException;
 import org.cardanofoundation.explorer.api.common.enumeration.AnalyticType;
 import org.cardanofoundation.explorer.api.config.LogMessage;
+import org.cardanofoundation.explorer.api.controller.validation.PageZeroValid;
 import org.cardanofoundation.explorer.api.model.response.BaseFilterResponse;
 import org.cardanofoundation.explorer.api.model.response.TxFilterResponse;
 import org.cardanofoundation.explorer.api.model.response.address.AddressAnalyticsResponse;
@@ -19,7 +20,6 @@ import lombok.RequiredArgsConstructor;
 import org.cardanofoundation.explorer.common.validation.pagination.Pagination;
 import org.cardanofoundation.explorer.common.validation.pagination.PaginationValid;
 import org.springdoc.core.annotations.ParameterObject;
-import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -31,6 +31,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v1/addresses")
 @RequiredArgsConstructor
+@Validated
 public class AddressController {
 
   private final AddressService addressService;
@@ -50,7 +51,7 @@ public class AddressController {
   @Operation(summary = "Get top addresses")
   @Validated
   public ResponseEntity<BaseFilterResponse<AddressFilterResponse>> getTopAddress(
-      @ParameterObject @PaginationValid Pagination pagination) {
+      @ParameterObject @PaginationValid @PageZeroValid Pagination pagination) {
     return ResponseEntity.ok(addressService.getTopAddress(pagination.toPageable()));
   }
 

--- a/src/main/java/org/cardanofoundation/explorer/api/controller/DelegationController.java
+++ b/src/main/java/org/cardanofoundation/explorer/api/controller/DelegationController.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.cardanofoundation.explorer.api.common.constant.CommonConstant;
 import org.cardanofoundation.explorer.api.config.LogMessage;
+import org.cardanofoundation.explorer.api.controller.validation.PageZeroValid;
 import org.cardanofoundation.explorer.api.model.response.BaseFilterResponse;
 import org.cardanofoundation.explorer.api.model.response.DelegationResponse;
 import org.cardanofoundation.explorer.api.model.response.PoolDetailDelegatorResponse;
@@ -73,7 +74,7 @@ public class DelegationController {
   @GetMapping("/pool-detail-epochs")
   public ResponseEntity<BaseFilterResponse<PoolDetailEpochResponse>> getEpochListForPoolDetail(
        @RequestParam("poolView") @PrefixedValid(CommonConstant.PREFIXED_POOL_VIEW) @LengthValid(CommonConstant.POOL_VIEW_LENGTH) String poolView,
-       @ParameterObject @PaginationValid @PaginationDefault(size = 10, page = 0) Pagination pagination) {
+       @ParameterObject @PaginationValid @PaginationDefault(size = 20, page = 0) Pagination pagination) {
     return ResponseEntity.ok(delegationService.getEpochListForPoolDetail(pagination.toPageable(), poolView));
   }
 
@@ -87,7 +88,7 @@ public class DelegationController {
   @GetMapping("/top")
   @LogMessage
   @Operation(summary = "Find Top(default is 3) Delegation Pool order by pool size")
-  public ResponseEntity<List<PoolResponse>> findTopDelegationPool(@PaginationValid Pagination pagination) {
+  public ResponseEntity<List<PoolResponse>> findTopDelegationPool(@PaginationValid @PageZeroValid Pagination pagination) {
     return ResponseEntity.ok(delegationService.findTopDelegationPool(pagination.toPageable()));
   }
 }

--- a/src/main/java/org/cardanofoundation/explorer/api/controller/EpochController.java
+++ b/src/main/java/org/cardanofoundation/explorer/api/controller/EpochController.java
@@ -56,7 +56,7 @@ public class EpochController {
   @LogMessage
   @Operation(summary = "Get all epoch")
   public ResponseEntity<BaseFilterResponse<EpochResponse>> filter(
-       @ParameterObject @PaginationValid @PaginationDefault(sort = {"id"},
+       @ParameterObject @PaginationValid @PaginationDefault(size = 20, sort = {"id"},
           direction = Sort.Direction.DESC) Pagination pagination) {
     return ResponseEntity.ok(epochService.getAllEpoch(pagination.toPageable()));
   }

--- a/src/main/java/org/cardanofoundation/explorer/api/controller/PoolController.java
+++ b/src/main/java/org/cardanofoundation/explorer/api/controller/PoolController.java
@@ -28,14 +28,14 @@ public class PoolController {
   @GetMapping("/registration")
   @LogMessage
   public ResponseEntity<BaseFilterResponse<PoolTxResponse>> getDataForPoolRegistration(
-       @ParameterObject @PaginationValid @PaginationDefault Pagination pagination) {
+       @ParameterObject @PaginationValid @PaginationDefault(size = 20) Pagination pagination) {
     return ResponseEntity.ok(poolRegistrationService.getDataForPoolRegistration(pagination.toPageable()));
   }
 
   @GetMapping("/de-registration")
   @LogMessage
   public ResponseEntity<BaseFilterResponse<PoolTxResponse>> getDataForPoolDeRegistration(
-       @ParameterObject @PaginationValid @PaginationDefault Pagination pagination) {
+       @ParameterObject @PaginationValid @PaginationDefault(size = 20) Pagination pagination) {
     return ResponseEntity.ok(poolRegistrationService.getDataForPoolDeRegistration(pagination.toPageable()));
   }
 }

--- a/src/main/java/org/cardanofoundation/explorer/api/controller/StakeKeyController.java
+++ b/src/main/java/org/cardanofoundation/explorer/api/controller/StakeKeyController.java
@@ -1,10 +1,12 @@
 package org.cardanofoundation.explorer.api.controller;
 
+import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 
 import org.cardanofoundation.explorer.api.common.constant.CommonConstant;
 import org.cardanofoundation.explorer.api.common.enumeration.AnalyticType;
 import org.cardanofoundation.explorer.api.config.LogMessage;
+import org.cardanofoundation.explorer.api.controller.validation.PageZeroValid;
 import org.cardanofoundation.explorer.api.controller.validation.StakeKeyLengthValid;
 import org.cardanofoundation.explorer.api.model.response.BaseFilterResponse;
 import org.cardanofoundation.explorer.api.model.response.StakeAnalyticResponse;
@@ -28,10 +30,12 @@ import java.util.List;
 
 import lombok.RequiredArgsConstructor;
 import org.cardanofoundation.explorer.common.validation.pagination.Pagination;
+import org.cardanofoundation.explorer.common.validation.pagination.PaginationDefault;
 import org.cardanofoundation.explorer.common.validation.pagination.PaginationValid;
 import org.cardanofoundation.explorer.common.validation.prefixed.PrefixedValid;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -125,7 +129,8 @@ public class StakeKeyController {
   @GetMapping("/top-delegators")
   @LogMessage
   @Operation(summary = "Get top delegators")
-  public BaseFilterResponse<StakeFilterResponse> getTopDelegators(@ParameterObject @PaginationValid Pagination pagination) {
+  public BaseFilterResponse<StakeFilterResponse> getTopDelegators(@ParameterObject @PaginationValid @PageZeroValid
+                                                                      Pagination pagination) {
     return stakeService.getTopDelegators(pagination.toPageable());
   }
 

--- a/src/main/java/org/cardanofoundation/explorer/api/controller/advice/GlobalRestControllerExceptionHandler.java
+++ b/src/main/java/org/cardanofoundation/explorer/api/controller/advice/GlobalRestControllerExceptionHandler.java
@@ -11,6 +11,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 import java.util.Arrays;
 
@@ -117,6 +118,18 @@ public class GlobalRestControllerExceptionHandler {
             ErrorResponse.builder()
                 .errorCode(String.valueOf(HttpStatus.BAD_REQUEST.value()))
                 .errorMessage(e.getMessage())
+                .build());
+  }
+
+  @ExceptionHandler({MethodArgumentTypeMismatchException.class})
+  public ResponseEntity<ErrorResponse> handleMethodArgumentTypeMismatch(MethodArgumentTypeMismatchException e) {
+    log.warn("Argument type not valid: {}", e.getMessage());
+
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+        .body(
+            ErrorResponse.builder()
+                .errorCode(String.valueOf(HttpStatus.BAD_REQUEST.value()))
+                .errorMessage(e.getName() + " not valid")
                 .build());
   }
 }

--- a/src/main/java/org/cardanofoundation/explorer/api/controller/validation/PageZeroValid.java
+++ b/src/main/java/org/cardanofoundation/explorer/api/controller/validation/PageZeroValid.java
@@ -1,0 +1,16 @@
+package org.cardanofoundation.explorer.api.controller.validation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.*;
+
+@Constraint(validatedBy = {PageZeroValidator.class})
+@Target({ElementType.PARAMETER, ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface PageZeroValid {
+  String message() default "The page number must be 0";
+  Class<?>[] groups() default {};
+  Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/org/cardanofoundation/explorer/api/controller/validation/PageZeroValidator.java
+++ b/src/main/java/org/cardanofoundation/explorer/api/controller/validation/PageZeroValidator.java
@@ -1,0 +1,13 @@
+package org.cardanofoundation.explorer.api.controller.validation;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import org.cardanofoundation.explorer.common.validation.pagination.Pagination;
+
+public class PageZeroValidator implements ConstraintValidator<PageZeroValid, Pagination> {
+
+  @Override
+  public boolean isValid(Pagination pagination, ConstraintValidatorContext context) {
+    return pagination.getPage() == null || pagination.getPage() == 0;
+  }
+}

--- a/src/main/java/org/cardanofoundation/explorer/api/service/impl/DelegationServiceImpl.java
+++ b/src/main/java/org/cardanofoundation/explorer/api/service/impl/DelegationServiceImpl.java
@@ -292,6 +292,8 @@ public class DelegationServiceImpl implements DelegationService {
     }
     response.setData(poolList);
     response.setTotalItems(poolIdPage.getTotalElements());
+    response.setTotalPages(poolIdPage.getTotalPages());
+    response.setCurrentPage(pageable.getPageNumber());
     return response;
   }
 
@@ -474,6 +476,7 @@ public class DelegationServiceImpl implements DelegationService {
         .orElseThrow(() -> new BusinessException(CommonErrorCode.UNKNOWN_ERROR));
     Long poolId = poolHash.getId();
     long totalElm;
+    int totalPage;
     Set<Integer> epochNos;
     Boolean isKoiOs = fetchRewardDataService.isKoiOs();
     if (Boolean.TRUE.equals(isKoiOs)) {
@@ -496,6 +499,7 @@ public class DelegationServiceImpl implements DelegationService {
       epochNos = poolHistoryKoiOsProjections.stream().map(PoolHistoryKoiosProjection::getEpochNo)
           .collect(
               Collectors.toSet());
+      totalPage = poolHistoryKoiOsProjections.getTotalPages();
     } else {
       Page<PoolActiveStakeProjection> epochStakeProjections = epochStakeRepository.getDataForEpochList(
           poolId, pageable);
@@ -503,6 +507,7 @@ public class DelegationServiceImpl implements DelegationService {
       totalElm = epochStakeProjections.getTotalElements();
       epochNos = epochStakeProjections.stream().map(PoolActiveStakeProjection::getEpochNo)
           .collect(Collectors.toSet());
+      totalPage = epochStakeProjections.getTotalPages();
       List<EpochRewardProjection> delegatorRewardProjections = rewardRepository.getDelegatorRewardByPool(
           poolId, epochNos);
       Map<Integer, BigInteger> delegatorRewardMap = delegatorRewardProjections.stream().collect(
@@ -536,6 +541,8 @@ public class DelegationServiceImpl implements DelegationService {
         epochOfPool -> epochOfPool.setBlock(epochBlockMap.get(epochOfPool.getEpoch())));
     epochRes.setData(epochOfPools);
     epochRes.setTotalItems(totalElm);
+    epochRes.setTotalPages(totalPage);
+    epochRes.setCurrentPage(pageable.getPageNumber());
     return epochRes;
   }
 
@@ -652,6 +659,10 @@ public class DelegationServiceImpl implements DelegationService {
       }
       delegatorResponse.setTotalItems(addressIdPage.getTotalElements());
       delegatorResponse.setData(delegatorList);
+      delegatorResponse.setTotalPages(addressIdPage.getTotalPages());
+      delegatorResponse.setCurrentPage(pageable.getPageNumber());
+    } else {
+      delegatorResponse.setData(new ArrayList<>());
     }
     return delegatorResponse;
   }

--- a/src/main/java/org/cardanofoundation/explorer/api/service/impl/PoolRegistrationServiceImpl.java
+++ b/src/main/java/org/cardanofoundation/explorer/api/service/impl/PoolRegistrationServiceImpl.java
@@ -41,6 +41,8 @@ public class PoolRegistrationServiceImpl implements PoolRegistrationService {
     setValueForPoolRegistration(poolTxRes);
     response.setData(poolTxRes);
     response.setTotalItems(trxBlockEpochPage.getTotalElements());
+    response.setCurrentPage(pageable.getPageNumber());
+    response.setTotalPages(trxBlockEpochPage.getTotalPages());
     return response;
   }
 

--- a/src/main/java/org/cardanofoundation/explorer/api/service/impl/StakeKeyServiceImpl.java
+++ b/src/main/java/org/cardanofoundation/explorer/api/service/impl/StakeKeyServiceImpl.java
@@ -193,6 +193,9 @@ public class StakeKeyServiceImpl implements StakeKeyService {
     });
     final int start = (int) pageable.getOffset();
     final int end = Math.min((start + pageable.getPageSize()), stakeHistoryList.size());
+    if (start >= stakeHistoryList.size()) {
+      return new BaseFilterResponse<>(new PageImpl<>(List.of()));
+    }
     Page<StakeHistoryProjection> page = new PageImpl<>(stakeHistoryList.subList(start, end),
         pageable, stakeHistoryList.size());
     return new BaseFilterResponse<>(page);
@@ -222,6 +225,11 @@ public class StakeKeyServiceImpl implements StakeKeyService {
     });
     final int start = (int) pageable.getOffset();
     final int end = Math.min((start + pageable.getPageSize()), instantaneousRewards.size());
+
+    if (start >= instantaneousRewards.size()) {
+      return new BaseFilterResponse<>(new PageImpl<>(List.of()));
+    }
+
     Page<StakeInstantaneousRewardsProjection> page = new PageImpl<>(
         instantaneousRewards.subList(start, end), pageable, instantaneousRewards.size());
     return new BaseFilterResponse<>(page);


### PR DESCRIPTION
## Subject

- Update API responses for improved coherence and logical consistency.

## Changes Description

- Adjusted the default page size in the following APIs:

    api/v1/epochs
    api/v1/pools/registration
    api/v1/pools/de-registration
    api/v1/epochs/:no/blocks
    api/v1/delegations/pool-detail-epochs
- Implemented validation for the input value of the following APIs:

    api/v1/stakes/top-delegators
    api/v1/addresses/top-addresses
    api/v1/delegations/top
- Added a common response for handling incorrect data type parameters.

- Modified the values of totalPage and currentPage in the following APIs:

    api/v1/pools/registration
    api/v1/delegations/pool-list
    api/v1/delegations/pool-detail-epochs
    api/v1/delegations/pool-detail-delegators
- Fixed  issues in the following APIs:

    api/v1/stakes/{stakeKey}/instantaneous-rewards
    api/v1/stakes/{stakeKey}/stake-history

