### PR TITLE
fix: find pool lifecycle  registration incorrect

### DIFF
--- a/src/main/java/org/cardanofoundation/explorer/api/repository/PoolHashRepository.java
+++ b/src/main/java/org/cardanofoundation/explorer/api/repository/PoolHashRepository.java
@@ -95,7 +95,7 @@ public interface PoolHashRepository extends JpaRepository<PoolHash, Long> {
       "SELECT pu.id AS poolUpdateId, pu.pledge AS pledge, pu.margin AS margin, pu.vrfKeyHash AS vrfKey, pu.fixedCost AS cost, tx.hash AS txHash, bk.time AS time, tx.deposit AS deposit, tx.fee AS fee, sa.view AS rewardAccount "
           + "FROM PoolHash ph "
           + "JOIN PoolUpdate pu ON ph.id = pu.poolHash.id "
-          + "JOIN Tx tx ON pu.registeredTx.id = tx.id AND tx.deposit IS NOT NULL AND tx.deposit > 0 "
+          + "JOIN Tx tx ON pu.registeredTx.id = tx.id AND tx.deposit IS NOT NULL AND tx.deposit = 500000000 "
           + "JOIN Block bk ON tx.block.id  = bk.id "
           + "JOIN StakeAddress sa ON pu.rewardAddr.id = sa.id "
           + "WHERE ph.view = :poolView")

--- a/src/main/java/org/cardanofoundation/explorer/api/repository/PoolUpdateRepository.java
+++ b/src/main/java/org/cardanofoundation/explorer/api/repository/PoolUpdateRepository.java
@@ -85,7 +85,7 @@ public interface PoolUpdateRepository extends JpaRepository<PoolUpdate, Long> {
       "SELECT pu.id AS poolUpdateId, tx.hash AS txHash, tx.fee AS fee, bk.time AS time, pu.margin AS margin "
           + "FROM PoolHash ph "
           + "JOIN PoolUpdate pu ON ph.id = pu.poolHash.id "
-          + "JOIN Tx tx ON pu.registeredTx.id  = tx.id AND (tx.deposit IS NULL OR tx.deposit = 0) "
+          + "JOIN Tx tx ON pu.registeredTx.id  = tx.id AND (tx.deposit IS NULL OR tx.deposit < 500000000) "
           + "JOIN Block bk ON tx.blockId = bk.id "
           + "WHERE ph.view = :poolView "
           + "AND (:txHash IS NULL OR tx.hash = :txHash) "
@@ -121,11 +121,11 @@ public interface PoolUpdateRepository extends JpaRepository<PoolUpdate, Long> {
       @Param("poolHashId") Long poolHashId);
 
   @Query(value =
-      "SELECT pu.id AS poolUpdateId, ph.id AS hashId, ph.hashRaw AS poolId , ph.view AS poolView, pod.poolName AS poolName, pu.pledge AS pledge, pu.margin AS margin, pu.vrfKeyHash AS vrfKey, pu.fixedCost  AS cost, tx.hash AS txHash, bk.time AS time, tx.fee AS fee, sa.view AS rewardAccount "
+      "SELECT pu.id AS poolUpdateId, ph.id AS hashId, ph.hashRaw AS poolId , ph.view AS poolView, pod.poolName AS poolName, pu.pledge AS pledge, pu.margin AS margin, pu.vrfKeyHash AS vrfKey, pu.fixedCost  AS cost, tx.hash AS txHash, bk.time AS time, tx.fee AS fee, sa.view AS rewardAccount, tx.deposit AS deposit "
           + "FROM PoolHash ph "
           + "LEFT JOIN PoolOfflineData pod ON ph.id = pod.pool.id AND pod.id = (SELECT max(pod2.id) FROM PoolOfflineData pod2 WHERE ph.id = pod2.pool.id) "
           + "JOIN PoolUpdate pu ON ph.id = pu.poolHash.id "
-          + "JOIN Tx tx ON pu.registeredTx.id = tx.id AND (tx.deposit IS NULL OR tx.deposit = 0) "
+          + "JOIN Tx tx ON pu.registeredTx.id = tx.id AND (tx.deposit IS NULL OR tx.deposit < 500000000) "
           + "JOIN Block bk ON tx.block.id  = bk.id "
           + "JOIN StakeAddress sa ON pu.rewardAddr.id  = sa.id "
           + "WHERE ph.view = :poolView ")
@@ -146,7 +146,7 @@ public interface PoolUpdateRepository extends JpaRepository<PoolUpdate, Long> {
       "SELECT pu.id AS poolUpdateId, tx.hash AS txHash, tx.fee AS fee, bk.time AS time, pu.margin AS margin, tx.deposit AS deposit "
           + "FROM PoolHash ph "
           + "JOIN PoolUpdate pu ON ph.id = pu.poolHash.id "
-          + "JOIN Tx tx ON pu.registeredTx.id  = tx.id AND tx.deposit IS NOT NULL AND tx.deposit > 0 "
+          + "JOIN Tx tx ON pu.registeredTx.id  = tx.id AND tx.deposit IS NOT NULL AND tx.deposit = 500000000 "
           + "JOIN Block bk ON tx.blockId = bk.id "
           + "WHERE ph.view = :poolView "
           + "AND (:txHash IS NULL OR tx.hash = :txHash) "


### PR DESCRIPTION
## Subject

- find pool lifecycle  registration incorrect

## Changes Description

- /api/v1/pool-lifecycle/registration
- /api/v1/pool-lifecycle/pool-update
- /api/v1/pool-lifecycle/registration-list
- /api/v1/pool-lifecycle/pool-update-list

## How to test

- {{baseUrl}}/api/v1/pool-lifecycle/pool-update-list?page=0&size=10&poolView=pool1kchver88u3kygsak8wgll7htr8uxn5v35lfrsyy842nkscrzyvj
- {{baseUrl}}/api/v1/pool-lifecycle/registration-list?page=0&size=10&poolView=pool1kchver88u3kygsak8wgll7htr8uxn5v35lfrsyy842nkscrzyvj
- {{baseUrl}}/api/v1/pool-lifecycle/registration?page=0&size=10&poolView=pool1kchver88u3kygsak8wgll7htr8uxn5v35lfrsyy842nkscrzyvj
{{baseUrl}}/api/v1/pool-lifecycle/pool-update?page=0&size=10&poolView=pool1kchver88u3kygsak8wgll7htr8uxn5v35lfrsyy842nkscrzyvj
## Evident for results

- 
![Screenshot from 2023-06-30 15-42-51](https://github.com/cardano-foundation/cf-explorer-api/assets/113956932/c0adc32e-82be-4e9f-97c4-3a60757591a4)

## Referenced Ticket

- https://jira.sotatek.com/projects/ADAE/issues/ADAE-810?filter=myopenissues
