### PR TITLE
ref: update response of getting script of contract

### DIFF
--- a/src/main/java/org/cardanofoundation/explorer/api/controller/ContractController.java
+++ b/src/main/java/org/cardanofoundation/explorer/api/controller/ContractController.java
@@ -4,6 +4,7 @@ import org.cardanofoundation.explorer.api.config.LogMessage;
 import org.cardanofoundation.explorer.api.model.request.ScriptVerifyRequest;
 import org.cardanofoundation.explorer.api.model.response.BaseFilterResponse;
 import org.cardanofoundation.explorer.api.model.response.contract.ContractFilterResponse;
+import org.cardanofoundation.explorer.api.model.response.contract.ContractScript;
 import org.cardanofoundation.explorer.api.service.AddressService;
 import org.cardanofoundation.explorer.consumercommon.entity.Address_;
 import io.swagger.v3.oas.annotations.Operation;
@@ -46,7 +47,7 @@ public class ContractController {
   @GetMapping("/{address}/script")
   @LogMessage
   @Operation(summary = "Get native script of contract")
-  public ResponseEntity<String> getScriptOfContract(@PathVariable String address) {
+  public ResponseEntity<ContractScript> getScriptOfContract(@PathVariable String address) {
     return ResponseEntity.ok(addressService.getJsonNativeScript(address));
   }
 }

--- a/src/main/java/org/cardanofoundation/explorer/api/model/response/contract/ContractScript.java
+++ b/src/main/java/org/cardanofoundation/explorer/api/model/response/contract/ContractScript.java
@@ -1,0 +1,15 @@
+package org.cardanofoundation.explorer.api.model.response.contract;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.*;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@JsonInclude
+public class ContractScript {
+    private Boolean isVerified;
+    private String data;
+}

--- a/src/main/java/org/cardanofoundation/explorer/api/service/AddressService.java
+++ b/src/main/java/org/cardanofoundation/explorer/api/service/AddressService.java
@@ -8,6 +8,7 @@ import org.cardanofoundation.explorer.api.model.response.address.AddressAnalytic
 import org.cardanofoundation.explorer.api.model.response.address.AddressFilterResponse;
 import org.cardanofoundation.explorer.api.model.response.address.AddressResponse;
 import org.cardanofoundation.explorer.api.model.response.contract.ContractFilterResponse;
+import org.cardanofoundation.explorer.api.model.response.contract.ContractScript;
 import org.cardanofoundation.explorer.api.model.response.token.TokenAddressResponse;
 import java.math.BigInteger;
 import java.util.List;
@@ -83,5 +84,5 @@ public interface AddressService {
    * @param address wallet address
    * @return json script
    */
-  String getJsonNativeScript(String address);
+  ContractScript getJsonNativeScript(String address);
 }

--- a/src/main/java/org/cardanofoundation/explorer/api/service/impl/AddressServiceImpl.java
+++ b/src/main/java/org/cardanofoundation/explorer/api/service/impl/AddressServiceImpl.java
@@ -20,6 +20,7 @@ import org.cardanofoundation.explorer.api.model.response.address.AddressAnalytic
 import org.cardanofoundation.explorer.api.model.response.address.AddressFilterResponse;
 import org.cardanofoundation.explorer.api.model.response.address.AddressResponse;
 import org.cardanofoundation.explorer.api.model.response.contract.ContractFilterResponse;
+import org.cardanofoundation.explorer.api.model.response.contract.ContractScript;
 import org.cardanofoundation.explorer.api.model.response.stake.StakeAnalyticBalanceResponse;
 import org.cardanofoundation.explorer.api.model.response.token.TokenAddressResponse;
 import org.cardanofoundation.explorer.api.projection.AddressTokenProjection;
@@ -395,13 +396,13 @@ public class AddressServiceImpl implements AddressService {
   }
 
   @Override
-  public String getJsonNativeScript(String address) {
+  public ContractScript getJsonNativeScript(String address) {
     Address addr = addressRepository.findFirstByAddress(address).orElseThrow(
         () -> new BusinessException(BusinessCode.ADDRESS_NOT_FOUND)
     );
 
     if(Boolean.FALSE.equals(addr.getVerifiedContract())){
-      return SCRIPT_NOT_VERIFIED;
+      return ContractScript.builder().isVerified(Boolean.FALSE).data(null).build();
     }
 
     ShelleyAddress shelleyAddress = new ShelleyAddress(addr.getAddress());
@@ -411,10 +412,10 @@ public class AddressServiceImpl implements AddressService {
     );
 
     if(Objects.isNull(script.getJson())){
-      return SCRIPT_NOT_VERIFIED;
+      return ContractScript.builder().isVerified(Boolean.FALSE).data(null).build();
     }
 
-    return script.getJson();
+    return ContractScript.builder().isVerified(Boolean.TRUE).data(script.getJson()).build();
   }
 
   private void setMetadata(List<TokenAddressResponse> tokenListResponse) {

--- a/src/test/java/org/cardanofoundation/explorer/api/service/AddressServiceTest.java
+++ b/src/test/java/org/cardanofoundation/explorer/api/service/AddressServiceTest.java
@@ -3,6 +3,7 @@ package org.cardanofoundation.explorer.api.service;
 import java.util.Optional;
 
 import org.cardanofoundation.explorer.api.model.request.ScriptVerifyRequest;
+import org.cardanofoundation.explorer.api.model.response.contract.ContractScript;
 import org.cardanofoundation.explorer.api.repository.AddressRepository;
 import org.cardanofoundation.explorer.api.repository.ScriptRepository;
 import org.cardanofoundation.explorer.api.service.impl.AddressServiceImpl;
@@ -23,8 +24,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(MockitoExtension.class)
-public class AddressServiceTest {
-  static final String SCRIPT_NOT_VERIFIED = "Script not verified";
+class AddressServiceTest {
 
   @Mock
   AddressRepository addressRepository;
@@ -76,7 +76,7 @@ public class AddressServiceTest {
   }
 
   @Test
-  void getJsonNativeScript_shouldReturnScripNotVerify_whenContractNotVerifyYet(){
+  void getJsonNativeScript_shouldReturnUnverifiedContractScript_whenContractNotVerifyYet(){
     Address address = Address.builder()
         .address("addr1zy6ndumcmaesy7wj86k8jwup0vn5vewklc6jxlrrxr5tjqda8awvzhtzntme2azmkacmvtc4ggrudqxcmyl245nq5taq6yclrm")
         .verifiedContract(false)
@@ -85,7 +85,10 @@ public class AddressServiceTest {
     when(addressRepository.findFirstByAddress(address.getAddress()))
         .thenReturn(Optional.of(address));
 
-    Assertions.assertEquals(addressService.getJsonNativeScript(address.getAddress()), SCRIPT_NOT_VERIFIED);
+    ContractScript contractScript = addressService.getJsonNativeScript(address.getAddress());
+
+    Assertions.assertFalse(contractScript.getIsVerified());
+    Assertions.assertNull(contractScript.getData());
   }
 
   @Test
@@ -107,12 +110,14 @@ public class AddressServiceTest {
     when(scriptRepository.findByHash(policyId))
         .thenReturn(Optional.of(script));
 
-    Assertions.assertEquals(addressService.getJsonNativeScript(address.getAddress()),
-                            script.getJson());
+    ContractScript contractScript = addressService.getJsonNativeScript(address.getAddress());
+
+    Assertions.assertTrue(contractScript.getIsVerified());
+    Assertions.assertEquals(script.getJson(), contractScript.getData());
   }
 
   @Test
-  void getJsonNativeScript_shouldReturnScripNotVerify_whenNativeScripJsonNull() {
+  void getJsonNativeScript_shouldReturnUnverifiedContractScript_whenNativeScripJsonNull() {
     Address address = Address.builder()
         .address(
             "addr1zy6ndumcmaesy7wj86k8jwup0vn5vewklc6jxlrrxr5tjqda8awvzhtzntme2azmkacmvtc4ggrudqxcmyl245nq5taq6yclrm")
@@ -129,7 +134,9 @@ public class AddressServiceTest {
     when(scriptRepository.findByHash(policyId))
         .thenReturn(Optional.of(script));
 
-    Assertions.assertEquals(addressService.getJsonNativeScript(address.getAddress()),
-                            SCRIPT_NOT_VERIFIED);
+    ContractScript contractScript = addressService.getJsonNativeScript(address.getAddress());
+
+    Assertions.assertFalse(contractScript.getIsVerified());
+    Assertions.assertNull(contractScript.getData());
   }
 }


### PR DESCRIPTION
## Subject

- Update response of the API: /api/v1/contracts/{address}/script

## Changes Description

- Instead of returning a string, modify the implementation to return an object that contains the returned script.

## How to test

- GET: /api/v1/contracts/addr1wytgw6nv2d3adkdz23s9ccxr4tlv60wvxtut0yyexqwseqswvv3j0/script

## Evident for results
![Screenshot from 2023-07-03 14-18-06](https://github.com/cardano-foundation/cf-explorer-api/assets/130524265/52df22a6-b582-4887-b6bf-623f88826432)


## Referenced Ticket

- https://cardanofoundation.atlassian.net/browse/MET-753
