### PR TITLE
fix: added redis cache TTL config for ada price

### DIFF
--- a/src/main/java/org/cardanofoundation/explorer/api/config/redis/cluster/RedisClusterConfig.java
+++ b/src/main/java/org/cardanofoundation/explorer/api/config/redis/cluster/RedisClusterConfig.java
@@ -1,30 +1,44 @@
 package org.cardanofoundation.explorer.api.config.redis.cluster;
 
 import lombok.extern.log4j.Log4j2;
+import lombok.val;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.annotation.CachingConfigurer;
+import org.springframework.cache.interceptor.KeyGenerator;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisClusterConfiguration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.GenericToStringSerializer;
 
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @Log4j2
 @Configuration
 @Profile("cluster")
-public class RedisClusterConfig {
+public class RedisClusterConfig implements CachingConfigurer {
 
     @Value("${spring.redis.cluster.nodes}")
     private List<String> nodes;
 
     @Value("${spring.redis.password}")
     private String password;
+
+    @Value("${application.api.coin.gecko.market.interval-time}")
+    private int apiMarketIntervalTime;
 
     @Bean(name = "lettuceConnectionFactory")
     @Autowired
@@ -57,4 +71,28 @@ public class RedisClusterConfig {
         redisTemplate.setValueSerializer(new GenericToStringSerializer<>(Object.class));
         return redisTemplate;
     }
+
+    @Override
+    public KeyGenerator keyGenerator() {
+        return (target, method, params) -> {
+            val sb = new StringBuilder();
+            sb.append(target.getClass().getName());
+            sb.append(method.getName());
+            Arrays.stream(params).sequential().forEach(sb::append);
+            log.info("call Redis cache Key : " + sb);
+            return sb.toString();
+        };
+    }
+
+    @Bean(name = "cacheManager")
+    public RedisCacheManager cacheManager(
+            @Qualifier("jedisConnectionFactory") RedisConnectionFactory connectionFactory) {
+        RedisCacheConfiguration coinPriceConf = RedisCacheConfiguration.defaultCacheConfig()
+                .entryTtl(Duration.ofSeconds(apiMarketIntervalTime));
+        Map<String, RedisCacheConfiguration> cacheConfigurations = new HashMap<>();
+        cacheConfigurations.put("market", coinPriceConf);
+        return RedisCacheManager.RedisCacheManagerBuilder.fromConnectionFactory(connectionFactory)
+                .withInitialCacheConfigurations(cacheConfigurations).build();
+    }
+
 }

--- a/src/main/java/org/cardanofoundation/explorer/api/config/redis/standalone/RedisStandaloneConfig.java
+++ b/src/main/java/org/cardanofoundation/explorer/api/config/redis/standalone/RedisStandaloneConfig.java
@@ -1,21 +1,33 @@
 package org.cardanofoundation.explorer.api.config.redis.standalone;
 
 import lombok.extern.log4j.Log4j2;
+import lombok.val;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.annotation.CachingConfigurer;
+import org.springframework.cache.interceptor.KeyGenerator;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.GenericToStringSerializer;
 
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
 @Log4j2
 @Configuration
 @Profile("standalone")
-public class RedisStandaloneConfig {
+public class RedisStandaloneConfig implements CachingConfigurer {
 
     @Value("${spring.redis.standalone.host}")
     private String hostname;
@@ -25,6 +37,9 @@ public class RedisStandaloneConfig {
 
     @Value("${spring.redis.password}")
     private String password;
+
+    @Value("${application.api.coin.gecko.market.interval-time}")
+    private int apiMarketIntervalTime;
 
     @Bean(name = "lettuceConnectionFactory")
     @Autowired
@@ -55,5 +70,28 @@ public class RedisStandaloneConfig {
         redisTemplate.setConnectionFactory(lettuceConnectionFactory);
         redisTemplate.setValueSerializer(new GenericToStringSerializer<>(Object.class));
         return redisTemplate;
+    }
+
+    @Override
+    public KeyGenerator keyGenerator() {
+        return (target, method, params) -> {
+            val sb = new StringBuilder();
+            sb.append(target.getClass().getName());
+            sb.append(method.getName());
+            Arrays.stream(params).sequential().forEach(sb::append);
+            log.info("call Redis cache Key : " + sb);
+            return sb.toString();
+        };
+    }
+
+    @Bean(name = "cacheManager")
+    public RedisCacheManager cacheManager(
+            @Qualifier("jedisConnectionFactory") RedisConnectionFactory connectionFactory) {
+        RedisCacheConfiguration coinPriceConf = RedisCacheConfiguration.defaultCacheConfig()
+                .entryTtl(Duration.ofSeconds(apiMarketIntervalTime));
+        Map<String, RedisCacheConfiguration> cacheConfigurations = new HashMap<>();
+        cacheConfigurations.put("market", coinPriceConf);
+        return RedisCacheManager.RedisCacheManagerBuilder.fromConnectionFactory(connectionFactory)
+                .withInitialCacheConfigurations(cacheConfigurations).build();
     }
 }


### PR DESCRIPTION
## Subject

Fixed a bug where the redis cache configuration was not active for Redis in `cluster` and `standalone` mode, but only `sentinel`

## Changes Description

Added missing Cache Configuration

## How to test

After deploy, ensure the ADA price is periodically updated on the UI

## Evident for results

N/A

## Referenced Ticket

- https://cardanofoundation.atlassian.net/browse/MET-1472
