### PR TITLE
fix: [MET-1475] update API responses for improved coherence and logical consistency

### DIFF
--- a/src/main/java/org/cardanofoundation/explorer/api/controller/AddressController.java
+++ b/src/main/java/org/cardanofoundation/explorer/api/controller/AddressController.java
@@ -3,6 +3,7 @@ package org.cardanofoundation.explorer.api.controller;
 import java.util.concurrent.ExecutionException;
 import org.cardanofoundation.explorer.api.common.enumeration.AnalyticType;
 import org.cardanofoundation.explorer.api.config.LogMessage;
+import org.cardanofoundation.explorer.api.controller.validation.PageZeroValid;
 import org.cardanofoundation.explorer.api.model.response.BaseFilterResponse;
 import org.cardanofoundation.explorer.api.model.response.TxFilterResponse;
 import org.cardanofoundation.explorer.api.model.response.address.AddressAnalyticsResponse;
@@ -49,7 +50,7 @@ public class AddressController {
   @LogMessage
   @Operation(summary = "Get top addresses")
   public ResponseEntity<BaseFilterResponse<AddressFilterResponse>> getTopAddress(
-      @ParameterObject @PaginationValid Pagination pagination) {
+      @ParameterObject @PaginationValid @PageZeroValid Pagination pagination) {
     return ResponseEntity.ok(addressService.getTopAddress(pagination.toPageable()));
   }
 

--- a/src/main/java/org/cardanofoundation/explorer/api/controller/DelegationController.java
+++ b/src/main/java/org/cardanofoundation/explorer/api/controller/DelegationController.java
@@ -5,6 +5,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.cardanofoundation.explorer.api.common.constant.CommonConstant;
 import org.cardanofoundation.explorer.api.config.LogMessage;
+import org.cardanofoundation.explorer.api.controller.validation.PageZeroValid;
 import org.cardanofoundation.explorer.api.model.response.BaseFilterResponse;
 import org.cardanofoundation.explorer.api.model.response.DelegationResponse;
 import org.cardanofoundation.explorer.api.model.response.PoolDetailDelegatorResponse;
@@ -92,7 +93,7 @@ public class DelegationController {
   @LogMessage
   @Operation(summary = "Find Top(default is 3) Delegation Pool order by pool size")
   public ResponseEntity<List<PoolResponse>> findTopDelegationPool(
-      @PaginationValid Pagination pagination) {
+      @PaginationValid @PageZeroValid Pagination pagination) {
     return ResponseEntity.ok(delegationService.findTopDelegationPool(pagination.toPageable()));
   }
 }

--- a/src/main/java/org/cardanofoundation/explorer/api/controller/EpochController.java
+++ b/src/main/java/org/cardanofoundation/explorer/api/controller/EpochController.java
@@ -45,7 +45,7 @@ public class EpochController {
   @Operation(summary = "Get block list of epoch by its no")
   public ResponseEntity<BaseFilterResponse<BlockFilterResponse>> getBlockList(
       @PathVariable @Parameter(description = "Epoch Number") String no,
-      @ParameterObject @PaginationValid @PaginationDefault(sort = {"id"},
+      @ParameterObject @PaginationValid @PaginationDefault(size = 20, sort = {"id"},
           direction = Sort.Direction.DESC) Pagination pagination) {
     return ResponseEntity.ok(blockService.getBlockByEpoch(no, pagination.toPageable()));
   }
@@ -54,7 +54,7 @@ public class EpochController {
   @LogMessage
   @Operation(summary = "Get all epoch")
   public ResponseEntity<BaseFilterResponse<EpochResponse>> filter(
-      @ParameterObject @PaginationValid @PaginationDefault(sort = {"id"},
+      @ParameterObject @PaginationValid @PaginationDefault(size = 20, sort = {"id"},
           direction = Sort.Direction.DESC) Pagination pagination) {
     return ResponseEntity.ok(epochService.getAllEpoch(pagination.toPageable()));
   }

--- a/src/main/java/org/cardanofoundation/explorer/api/controller/StakeKeyController.java
+++ b/src/main/java/org/cardanofoundation/explorer/api/controller/StakeKeyController.java
@@ -5,6 +5,7 @@ import java.util.concurrent.ExecutionException;
 import org.cardanofoundation.explorer.api.common.constant.CommonConstant;
 import org.cardanofoundation.explorer.api.common.enumeration.AnalyticType;
 import org.cardanofoundation.explorer.api.config.LogMessage;
+import org.cardanofoundation.explorer.api.controller.validation.PageZeroValid;
 import org.cardanofoundation.explorer.api.controller.validation.StakeKeyLengthValid;
 import org.cardanofoundation.explorer.api.model.response.BaseFilterResponse;
 import org.cardanofoundation.explorer.api.model.response.StakeAnalyticResponse;
@@ -124,7 +125,8 @@ public class StakeKeyController {
   @GetMapping("/top-delegators")
   @LogMessage
   @Operation(summary = "Get top delegators")
-  public BaseFilterResponse<StakeFilterResponse> getTopDelegators(@ParameterObject @PaginationValid Pagination pagination) {
+  public BaseFilterResponse<StakeFilterResponse> getTopDelegators(@ParameterObject @PaginationValid
+                                                                    @PageZeroValid Pagination pagination) {
     return stakeService.getTopDelegators(pagination.toPageable());
   }
 

--- a/src/main/java/org/cardanofoundation/explorer/api/controller/advice/GlobalRestControllerExceptionHandler.java
+++ b/src/main/java/org/cardanofoundation/explorer/api/controller/advice/GlobalRestControllerExceptionHandler.java
@@ -12,6 +12,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 import java.util.Arrays;
 
@@ -124,6 +125,18 @@ public class GlobalRestControllerExceptionHandler {
             ErrorResponse.builder()
                 .errorCode(String.valueOf(HttpStatus.BAD_REQUEST.value()))
                 .errorMessage(e.getMessage())
+                .build());
+  }
+
+  @ExceptionHandler({MethodArgumentTypeMismatchException.class})
+  public ResponseEntity<ErrorResponse> handleMethodArgumentTypeMismatch(MethodArgumentTypeMismatchException e) {
+    log.warn("Argument type not valid: {}", e.getMessage());
+
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+        .body(
+            ErrorResponse.builder()
+                .errorCode(String.valueOf(HttpStatus.BAD_REQUEST.value()))
+                .errorMessage(e.getName() + " not valid")
                 .build());
   }
 }

--- a/src/main/java/org/cardanofoundation/explorer/api/controller/validation/PageZeroValid.java
+++ b/src/main/java/org/cardanofoundation/explorer/api/controller/validation/PageZeroValid.java
@@ -1,0 +1,16 @@
+package org.cardanofoundation.explorer.api.controller.validation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.*;
+
+@Constraint(validatedBy = {PageZeroValidator.class})
+@Target({ElementType.PARAMETER, ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface PageZeroValid {
+  String message() default "The page number must be 0";
+  Class<?>[] groups() default {};
+  Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/org/cardanofoundation/explorer/api/controller/validation/PageZeroValidator.java
+++ b/src/main/java/org/cardanofoundation/explorer/api/controller/validation/PageZeroValidator.java
@@ -1,0 +1,13 @@
+package org.cardanofoundation.explorer.api.controller.validation;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import org.cardanofoundation.explorer.common.validation.pagination.Pagination;
+
+public class PageZeroValidator implements ConstraintValidator<PageZeroValid, Pagination> {
+
+  @Override
+  public boolean isValid(Pagination pagination, ConstraintValidatorContext context) {
+    return pagination.getPage() == null || pagination.getPage() == 0;
+  }
+}

--- a/src/main/java/org/cardanofoundation/explorer/api/service/impl/DelegationServiceImpl.java
+++ b/src/main/java/org/cardanofoundation/explorer/api/service/impl/DelegationServiceImpl.java
@@ -286,6 +286,9 @@ public class DelegationServiceImpl implements DelegationService {
     }
     response.setData(poolList);
     response.setTotalItems(poolIdPage.getTotalElements());
+    response.setTotalPages(poolIdPage.getTotalPages());
+    response.setCurrentPage(pageable.getPageNumber());
+
     return response;
   }
 
@@ -441,6 +444,7 @@ public class DelegationServiceImpl implements DelegationService {
         .orElseThrow(() -> new NoContentException(CommonErrorCode.UNKNOWN_ERROR));
     Long poolId = poolHash.getId();
     long totalElm;
+    int totalPage;
     Set<Integer> epochNos;
     Boolean isKoiOs = fetchRewardDataService.isKoiOs();
     if (Boolean.TRUE.equals(isKoiOs)) {
@@ -463,6 +467,7 @@ public class DelegationServiceImpl implements DelegationService {
       epochNos = poolHistoryKoiOsProjections.stream().map(PoolHistoryKoiosProjection::getEpochNo)
           .collect(
               Collectors.toSet());
+      totalPage = poolHistoryKoiOsProjections.getTotalPages();
     } else {
       Page<PoolActiveStakeProjection> epochStakeProjections = epochStakeRepository.getDataForEpochList(
           poolId, pageable);
@@ -470,6 +475,7 @@ public class DelegationServiceImpl implements DelegationService {
       totalElm = epochStakeProjections.getTotalElements();
       epochNos = epochStakeProjections.stream().map(PoolActiveStakeProjection::getEpochNo)
           .collect(Collectors.toSet());
+      totalPage = epochStakeProjections.getTotalPages();
       List<EpochRewardProjection> delegatorRewardProjections = rewardRepository.getDelegatorRewardByPool(
           poolId, epochNos);
       Map<Integer, BigInteger> delegatorRewardMap = delegatorRewardProjections.stream().collect(
@@ -503,6 +509,8 @@ public class DelegationServiceImpl implements DelegationService {
         epochOfPool -> epochOfPool.setBlock(epochBlockMap.get(epochOfPool.getEpoch())));
     epochRes.setData(epochOfPools);
     epochRes.setTotalItems(totalElm);
+    epochRes.setTotalPages(totalPage);
+    epochRes.setCurrentPage(pageable.getPageNumber());
     return epochRes;
   }
 
@@ -619,6 +627,10 @@ public class DelegationServiceImpl implements DelegationService {
       }
       delegatorResponse.setTotalItems(addressIdPage.getTotalElements());
       delegatorResponse.setData(delegatorList);
+      delegatorResponse.setTotalPages(addressIdPage.getTotalPages());
+      delegatorResponse.setCurrentPage(pageable.getPageNumber());
+    } else {
+      delegatorResponse.setData(new ArrayList<>());
     }
     return delegatorResponse;
   }

--- a/src/main/java/org/cardanofoundation/explorer/api/service/impl/PoolRegistrationServiceImpl.java
+++ b/src/main/java/org/cardanofoundation/explorer/api/service/impl/PoolRegistrationServiceImpl.java
@@ -41,6 +41,8 @@ public class PoolRegistrationServiceImpl implements PoolRegistrationService {
     setValueForPoolRegistration(poolTxRes);
     response.setData(poolTxRes);
     response.setTotalItems(trxBlockEpochPage.getTotalElements());
+    response.setCurrentPage(pageable.getPageNumber());
+    response.setTotalPages(trxBlockEpochPage.getTotalPages());
     return response;
   }
 
@@ -53,6 +55,8 @@ public class PoolRegistrationServiceImpl implements PoolRegistrationService {
     setValueForPoolRegistration(poolTxRes);
     response.setData(poolTxRes);
     response.setTotalItems(trxBlockEpochPage.getTotalElements());
+    response.setCurrentPage(pageable.getPageNumber());
+    response.setTotalPages(trxBlockEpochPage.getTotalPages());
     return response;
   }
 

--- a/src/main/java/org/cardanofoundation/explorer/api/service/impl/StakeKeyServiceImpl.java
+++ b/src/main/java/org/cardanofoundation/explorer/api/service/impl/StakeKeyServiceImpl.java
@@ -180,6 +180,9 @@ public class StakeKeyServiceImpl implements StakeKeyService {
     });
     final int start = (int) pageable.getOffset();
     final int end = Math.min((start + pageable.getPageSize()), stakeHistoryList.size());
+    if (start >= stakeHistoryList.size()) {
+      return new BaseFilterResponse<>(new PageImpl<>(List.of()));
+    }
     Page<StakeHistoryProjection> page = new PageImpl<>(stakeHistoryList.subList(start, end),
         pageable, stakeHistoryList.size());
     return new BaseFilterResponse<>(page);
@@ -209,6 +212,9 @@ public class StakeKeyServiceImpl implements StakeKeyService {
     });
     final int start = (int) pageable.getOffset();
     final int end = Math.min((start + pageable.getPageSize()), instantaneousRewards.size());
+    if (start >= instantaneousRewards.size()) {
+      return new BaseFilterResponse<>(new PageImpl<>(List.of()));
+    }
     Page<StakeInstantaneousRewardsProjection> page = new PageImpl<>(
         instantaneousRewards.subList(start, end), pageable, instantaneousRewards.size());
     return new BaseFilterResponse<>(page);


### PR DESCRIPTION
## Subject

- Update API responses for improved coherence and logical consistency.

## Changes Description

- Adjusted the default page size in the following APIs:

    api/v1/epochs
    api/v1/pools/registration
    api/v1/pools/de-registration
    api/v1/epochs/:no/blocks
    api/v1/delegations/pool-detail-epochs
- Implemented validation for the input value of the following APIs:

    api/v1/stakes/top-delegators
    api/v1/addresses/top-addresses
    api/v1/delegations/top
- Added a common response for handling incorrect data type parameters.

- Modified the values of totalPage and currentPage in the following APIs:

    api/v1/pools/registration
    api/v1/delegations/pool-list
    api/v1/delegations/pool-detail-epochs
    api/v1/delegations/pool-detail-delegators
- Fixed   issues in the following APIs:

    api/v1/stakes/{stakeKey}/instantaneous-rewards
    api/v1/stakes/{stakeKey}/stake-history

