### PR TITLE
fix: set default value for pool chart api

### DIFF
--- a/src/main/java/org/cardanofoundation/explorer/api/model/response/pool/chart/DelegatorChartResponse.java
+++ b/src/main/java/org/cardanofoundation/explorer/api/model/response/pool/chart/DelegatorChartResponse.java
@@ -1,5 +1,12 @@
 package org.cardanofoundation.explorer.api.model.response.pool.chart;
 
+import java.util.List;
+
 public class DelegatorChartResponse extends BasePoolChart<DelegatorChartList, Long> {
 
+  public DelegatorChartResponse() {
+    this.setDataByDays(List.of());
+    this.setHighest(0L);
+    this.setLowest(0L);
+  }
 }

--- a/src/main/java/org/cardanofoundation/explorer/api/model/response/pool/chart/EpochChartResponse.java
+++ b/src/main/java/org/cardanofoundation/explorer/api/model/response/pool/chart/EpochChartResponse.java
@@ -1,7 +1,13 @@
 package org.cardanofoundation.explorer.api.model.response.pool.chart;
 
 import java.math.BigInteger;
+import java.util.List;
 
 public class EpochChartResponse extends BasePoolChart<EpochChartList, BigInteger> {
 
+  public EpochChartResponse() {
+    this.setDataByDays(List.of());
+    this.setLowest(BigInteger.ZERO);
+    this.setHighest(BigInteger.ZERO);
+  }
 }


### PR DESCRIPTION
## Subject

- Set default value for pool chart API

## Changes Description

- /api/v1/delegations/pool-detail-analytics

## How to test

- {{baseUrl}}/api/v1/delegations/pool-detail-analytics?poolView=pool1haus36sw7cwyg8jdeg882mentse5txac7fmeew8ketuwky6q602

## Evident for results

- 
![Screenshot from 2023-07-28 16-48-36](https://github.com/cardano-foundation/cf-explorer-api/assets/113956932/0c488ab4-9201-4ab3-a932-e0dbf7f821e9)


## Referenced Ticket

- 
