### PR TITLE
Feature/met 1503 check cip 83

### DIFF
--- a/src/main/java/org/cardanofoundation/explorer/api/common/enumeration/MetadataField.java
+++ b/src/main/java/org/cardanofoundation/explorer/api/common/enumeration/MetadataField.java
@@ -21,7 +21,9 @@ public enum MetadataField {
   LINKS("links"), NAME("name"), IMAGE("image"), MEDIA_TYPE("mediaType"),
   DESCRIPTION("description"), VERSION("version"), POLICY_ID("policy_id"), ASSET_NAME("asset_name"),
   SRC("src"), FILES("files"), CONTRIBUTING_ARTISTS("contributing_artists"), RELEASE("release"), RELEASE_TITLE("release_title"),
-  SONG("song")
+  SONG("song"),
+  // CIP 20, CIP 83
+  MSG("msg"), ENC("enc")
   ;
 
   private final String name;

--- a/src/main/java/org/cardanofoundation/explorer/api/model/response/tx/TxMetadataResponse.java
+++ b/src/main/java/org/cardanofoundation/explorer/api/model/response/tx/TxMetadataResponse.java
@@ -3,6 +3,8 @@ package org.cardanofoundation.explorer.api.model.response.tx;
 import lombok.*;
 
 import java.math.BigInteger;
+import java.util.Map;
+
 import org.cardanofoundation.explorer.api.model.metadatastandard.cip.MetadataCIP;
 
 @Getter
@@ -15,4 +17,6 @@ public class TxMetadataResponse {
   private String value;
   private MetadataCIP metadataCIP25;
   private MetadataCIP metadataCIP60;
+  private Map<String,Object> metadataCIP20;
+  private Map<String,Object> metadataCIP83;
 }

--- a/src/main/java/org/cardanofoundation/explorer/api/service/impl/TxServiceImpl.java
+++ b/src/main/java/org/cardanofoundation/explorer/api/service/impl/TxServiceImpl.java
@@ -64,8 +64,7 @@ import org.cardanofoundation.explorer.api.repository.ledgersync.UnconsumeTxInRep
 import org.cardanofoundation.explorer.api.repository.ledgersync.WithdrawalRepository;
 import org.cardanofoundation.explorer.api.projection.*;
 import org.cardanofoundation.explorer.api.service.ProtocolParamService;
-import org.cardanofoundation.explorer.api.util.MetadataCIP25Utils;
-import org.cardanofoundation.explorer.api.util.MetadataCIP60Utils;
+import org.cardanofoundation.explorer.api.util.*;
 import org.cardanofoundation.explorer.common.exceptions.NoContentException;
 import org.cardanofoundation.explorer.consumercommon.entity.*;
 import org.springframework.beans.factory.annotation.Value;
@@ -106,7 +105,6 @@ import org.cardanofoundation.explorer.api.projection.TxContractProjection;
 import org.cardanofoundation.explorer.api.projection.TxGraphProjection;
 import org.cardanofoundation.explorer.api.projection.TxIOProjection;
 import org.cardanofoundation.explorer.api.service.TxService;
-import org.cardanofoundation.explorer.api.util.HexUtils;
 import org.cardanofoundation.explorer.common.exceptions.BusinessException;
 
 @Service
@@ -601,7 +599,9 @@ public class TxServiceImpl implements TxService {
             TxMetadataResponse.builder().label(txMetadata.getKey()).value(txMetadata.getJson())
                 .metadataCIP25(
                     MetadataCIP25Utils.standard(txMetadata.getJson()))
-                .metadataCIP60(MetadataCIP60Utils.standard(txMetadata.getJson())).build()).toList();
+                .metadataCIP60(MetadataCIP60Utils.standard(txMetadata.getJson()))
+                .metadataCIP20(MetadataCIP20Utils.standard(txMetadata.getJson()))
+                .metadataCIP83(MetadataCIP83Utils.standard(txMetadata.getJson())).build()).toList();
     if (!CollectionUtils.isEmpty(txMetadataList)) {
       txResponse.setMetadata(txMetadataList);
     }

--- a/src/main/java/org/cardanofoundation/explorer/api/util/MetadataCIP20Utils.java
+++ b/src/main/java/org/cardanofoundation/explorer/api/util/MetadataCIP20Utils.java
@@ -1,0 +1,70 @@
+package org.cardanofoundation.explorer.api.util;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.cardanofoundation.explorer.api.common.constant.CommonConstant;
+import org.cardanofoundation.explorer.api.common.enumeration.MetadataField;
+import org.cardanofoundation.explorer.api.model.metadatastandard.BaseProperty;
+
+import java.util.*;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@Slf4j
+public class MetadataCIP20Utils {
+  private static final String FIELD_REQUIRED_PROPERTIES = "requiredProperties";
+  private static final String FIELD_VALID = "valid";
+
+  @SuppressWarnings("unchecked")
+  public static Map<String, Object> standard(String jsonMetadata) {
+    Map<String, Object> metadataCIP = new HashMap<>();
+    List<BaseProperty> requiredProperties = new ArrayList<>();
+
+    try {
+      ObjectMapper objectMapper = new ObjectMapper();
+      Map<Object, Object> metadataMap = objectMapper.readValue(jsonMetadata, new TypeReference<>() {
+      });
+
+      var msg = metadataMap.get(MetadataField.MSG.getName());
+      requiredProperties.add(msg(msg, "1"));
+
+    } catch (Exception ex) {
+      log.error("Error: structure incorrect, message=" + ex.getMessage());
+      log.error("Check standard CIP-20 fail");
+    }
+
+    metadataCIP.put(FIELD_REQUIRED_PROPERTIES, requiredProperties);
+    metadataCIP.put(FIELD_VALID, isCIPValid(requiredProperties));
+    return metadataCIP;
+  }
+
+  public static BaseProperty msg(Object msg, String index){
+      return BaseProperty.builder()
+                      .index(index)
+                      .property(MetadataField.MSG.getName())
+                      .format(CommonConstant.FIELD_TYPE[13])
+                      .valid(isMsgValid(msg))
+                      .value(msg)
+                      .build();
+  }
+
+  public static boolean isMsgValid(Object msg){
+      if (Objects.nonNull(msg) && msg instanceof ArrayList<?>){
+          List<?> messages = (ArrayList<?>) msg;
+          if (messages.stream().allMatch(m -> m instanceof String
+                  && ((String) m).length() <= 64)){
+              return true;
+          }
+      }
+      return false;
+  }
+
+  public static boolean isCIPValid(List<BaseProperty> baseProperties){
+      if (baseProperties.isEmpty())
+          return false;
+      return baseProperties.stream().allMatch(baseProperty -> baseProperty.getValid().equals(Boolean.TRUE));
+  }
+
+}

--- a/src/main/java/org/cardanofoundation/explorer/api/util/MetadataCIP83Utils.java
+++ b/src/main/java/org/cardanofoundation/explorer/api/util/MetadataCIP83Utils.java
@@ -1,0 +1,62 @@
+package org.cardanofoundation.explorer.api.util;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.cardanofoundation.explorer.api.common.constant.CommonConstant;
+import org.cardanofoundation.explorer.api.common.enumeration.MetadataField;
+import org.cardanofoundation.explorer.api.model.metadatastandard.BaseProperty;
+
+import java.util.*;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@Slf4j
+public class MetadataCIP83Utils {
+  private static final String FIELD_REQUIRED_PROPERTIES = "requiredProperties";
+  private static final String FIELD_VALID = "valid";
+
+  @SuppressWarnings("unchecked")
+  public static Map<String, Object> standard(String jsonMetadata) {
+    Map<String, Object> metadataCIP = new HashMap<>();
+    List<BaseProperty> requiredProperties = new ArrayList<>();
+
+    try {
+      ObjectMapper objectMapper = new ObjectMapper();
+      Map<Object, Object> metadataMap = objectMapper.readValue(jsonMetadata, new TypeReference<>() {
+      });
+
+      var enc = metadataMap.get(MetadataField.ENC.getName());
+      var msg = metadataMap.get(MetadataField.MSG.getName());
+
+      requiredProperties.add(enc(enc, "1"));
+      requiredProperties.add(MetadataCIP20Utils.msg(msg, "2"));
+
+    } catch (Exception ex) {
+      log.error("Error: structure incorrect, message=" + ex.getMessage());
+      log.error("Check standard CIP-83 fail");
+    }
+
+    metadataCIP.put(FIELD_REQUIRED_PROPERTIES, requiredProperties);
+    metadataCIP.put(FIELD_VALID, isCIPValid(requiredProperties));
+    return metadataCIP;
+  }
+
+  public static BaseProperty enc(Object enc, String index){
+      return BaseProperty.builder()
+              .index(index)
+              .property(MetadataField.ENC.getName())
+              .format(CommonConstant.FIELD_TYPE[0])
+              .valid(Objects.nonNull(enc) && enc instanceof String)
+              .value(enc)
+              .build();
+  }
+
+  public static boolean isCIPValid(List<BaseProperty> baseProperties){
+      if (baseProperties.isEmpty())
+          return false;
+      return baseProperties.stream().allMatch(baseProperty -> baseProperty.getValid().equals(Boolean.TRUE));
+  }
+
+}


### PR DESCRIPTION
## Subject

- Add logic for checking cip 20 and cip 83 metadata in get tx detail api.

## Changes Description

- Add logic for checking cip 20 and cip 83 metadata in get tx detail api.

## How to test

- Get a tx hash of tx with cip 20 or cip 83 metadata format and call api get tx detail.

## Evident for results

-  ![image](https://github.com/cardano-foundation/cf-explorer-api/assets/124112689/1291cda2-32e6-44d0-88e9-805c2dbb3159)
## Referenced Ticket

- https://cardanofoundation.atlassian.net/browse/MET-1503
- https://cardanofoundation.atlassian.net/browse/MET-1498
